### PR TITLE
fix: use the shared semver implementation for the row Action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ result-*
 build/
 generated_code/
 logos-cpp-sdk/
+# Shared semver headers staged from logos-package by the flake's preConfigure.
+vendor/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,4 +24,8 @@ logos_module(
         src/PackagesPagingProxy.cpp
         src/PackageTypes.h
         src/PackageTypes.cpp
+    INCLUDE_DIRS
+        # Shared semver headers, staged from logos-package by the flake's
+        # preConfigure. Headers only — nothing here links liblgx.
+        ${CMAKE_CURRENT_SOURCE_DIR}/vendor
 )

--- a/flake.lock
+++ b/flake.lock
@@ -28021,11 +28021,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782484430,
-        "narHash": "sha256-gm+SLNULJn1BHMKOP0aOFkX6T/I20ZlzzatB/OhM6AI=",
+        "lastModified": 1784207645,
+        "narHash": "sha256-FEq/vi4ejVFmltUFl6SuP7WwKgy7JgZULekYcUWmUKE=",
         "owner": "logos-co",
         "repo": "logos-package-downloader",
-        "rev": "1e843e72bd7debedc2fd5a295684574189231df7",
+        "rev": "736f8ebcf06f754a58e80bde0a51645070418573",
         "type": "github"
       },
       "original": {
@@ -29312,11 +29312,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782134133,
-        "narHash": "sha256-65w2mEijAjUPVntS3kUKZygjRkZoj7dgCYtk8lD5jL8=",
+        "lastModified": 1784207525,
+        "narHash": "sha256-D1sVtUEcHjqUyYV0qEP+ORo4g7mzThz0cuHw+Taiwyg=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "4871ed198d6e35f198af15c93afd184aa36788e0",
+        "rev": "202af6fa0f0f4493bc59c8a609dff9326f78a18d",
         "type": "github"
       },
       "original": {
@@ -29768,11 +29768,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781873979,
-        "narHash": "sha256-Z5XUSB9wfdrmQhG/0fehJeBd9CjrlIEeO+mKDhE46H4=",
+        "lastModified": 1784140006,
+        "narHash": "sha256-Pcpku7qHRkDgEiWfFRJ/4dCF7m4MzS138dwv8PgmlNU=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "c207525d30f48620696668c38486884bad5384bc",
+        "rev": "8d4236f9453bce8b44dfd2f85a5006af993b7ed2",
         "type": "github"
       },
       "original": {
@@ -31890,11 +31890,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782153303,
-        "narHash": "sha256-h1ltzc34iMkXduTm/41Tma1chBXZolKJhamUqz1vH6w=",
+        "lastModified": 1784140006,
+        "narHash": "sha256-Pcpku7qHRkDgEiWfFRJ/4dCF7m4MzS138dwv8PgmlNU=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "53336d37e4efb7c8e8243347ab77ab78705214c9",
+        "rev": "8d4236f9453bce8b44dfd2f85a5006af993b7ed2",
         "type": "github"
       },
       "original": {
@@ -62408,11 +62408,11 @@
         "logos-package-downloader": "logos-package-downloader"
       },
       "locked": {
-        "lastModified": 1782499393,
-        "narHash": "sha256-WcLd0zCD/R9zG7EKpFXPXhuuyldufycsd62WhoUYluI=",
+        "lastModified": 1784209035,
+        "narHash": "sha256-rc3SHfjZDOAyFhr1ILXQtUoGP4ffKsURBFhSDJOq6Z4=",
         "owner": "logos-co",
         "repo": "logos-package-downloader-module",
-        "rev": "e6289af5ef9dc3ff27752b4475708ccc8d865261",
+        "rev": "02fcb4abd85fe2eef26094dd3cb46ed5585867c8",
         "type": "github"
       },
       "original": {
@@ -62427,11 +62427,11 @@
         "logos-package-manager": "logos-package-manager_43"
       },
       "locked": {
-        "lastModified": 1782499400,
-        "narHash": "sha256-JTA3QDUXFNPLgJkKPc4huWzQxTb5eZcVew31pljXKv8=",
+        "lastModified": 1784208334,
+        "narHash": "sha256-3aA1n6M1P41nMgeZmZ/s72WOY87FrxFSOIGJ4c4NfM8=",
         "owner": "logos-co",
         "repo": "logos-package-manager-module",
-        "rev": "128f543564acdb09ebf4c27574eca5ba88e2297e",
+        "rev": "439b580b115718a3b2e1637f2816b8ea6ea7decc",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -30614,11 +30614,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784064689,
-        "narHash": "sha256-vXyV1NJL6S/FHXWxfVPuOTnAE4U+UKwSyoBRYoLVUZc=",
+        "lastModified": 1784140006,
+        "narHash": "sha256-Pcpku7qHRkDgEiWfFRJ/4dCF7m4MzS138dwv8PgmlNU=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "cba119c08a377621ffa14994901e49f5f8d82f5e",
+        "rev": "8d4236f9453bce8b44dfd2f85a5006af993b7ed2",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -30614,11 +30614,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784062467,
-        "narHash": "sha256-WhmfrFrvcsj3I3sSuoNWb2hkJn/Ir/fRcNav5WQpd2E=",
+        "lastModified": 1784064689,
+        "narHash": "sha256-vXyV1NJL6S/FHXWxfVPuOTnAE4U+UKwSyoBRYoLVUZc=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "9642c98304233f6c8344220c93b3e13768be8a38",
+        "rev": "cba119c08a377621ffa14994901e49f5f8d82f5e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -30,7 +30,7 @@
     "default-container_2": {
       "inputs": {
         "logos-container": "logos-container_6",
-        "logos-nix": "logos-nix_431",
+        "logos-nix": "logos-nix_432",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -58,7 +58,7 @@
     "default-container_3": {
       "inputs": {
         "logos-container": "logos-container_11",
-        "logos-nix": "logos-nix_731",
+        "logos-nix": "logos-nix_732",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -142,7 +142,7 @@
         ],
         "logos-module": "logos-module_57",
         "logos-module-loader": "logos-module-loader_3",
-        "logos-nix": "logos-nix_436",
+        "logos-nix": "logos-nix_437",
         "logos-protocol": [
           "package_downloader",
           "logos-module-builder",
@@ -193,7 +193,7 @@
         ],
         "logos-module": "logos-module_94",
         "logos-module-loader": "logos-module-loader_5",
-        "logos-nix": "logos-nix_736",
+        "logos-nix": "logos-nix_737",
         "logos-protocol": [
           "package_manager",
           "logos-module-builder",
@@ -480,7 +480,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_47",
-        "logos-nix": "logos-nix_322",
+        "logos-nix": "logos-nix_323",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -513,7 +513,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_33",
         "logos-module": "logos-module_48",
-        "logos-nix": "logos-nix_327",
+        "logos-nix": "logos-nix_328",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -596,7 +596,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_53",
-        "logos-nix": "logos-nix_366",
+        "logos-nix": "logos-nix_367",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -630,7 +630,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_38",
         "logos-module": "logos-module_54",
-        "logos-nix": "logos-nix_371",
+        "logos-nix": "logos-nix_372",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -714,7 +714,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_64",
-        "logos-nix": "logos-nix_452",
+        "logos-nix": "logos-nix_453",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -748,7 +748,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_46",
         "logos-module": "logos-module_65",
-        "logos-nix": "logos-nix_457",
+        "logos-nix": "logos-nix_458",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -815,7 +815,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_70",
-        "logos-nix": "logos-nix_496",
+        "logos-nix": "logos-nix_497",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -850,7 +850,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_51",
         "logos-module": "logos-module_71",
-        "logos-nix": "logos-nix_501",
+        "logos-nix": "logos-nix_502",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -976,7 +976,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_84",
-        "logos-nix": "logos-nix_622",
+        "logos-nix": "logos-nix_623",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -1009,7 +1009,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_61",
         "logos-module": "logos-module_85",
-        "logos-nix": "logos-nix_627",
+        "logos-nix": "logos-nix_628",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -1074,7 +1074,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_90",
-        "logos-nix": "logos-nix_666",
+        "logos-nix": "logos-nix_667",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -1108,7 +1108,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_66",
         "logos-module": "logos-module_91",
-        "logos-nix": "logos-nix_671",
+        "logos-nix": "logos-nix_672",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -1192,7 +1192,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_101",
-        "logos-nix": "logos-nix_752",
+        "logos-nix": "logos-nix_753",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -1226,7 +1226,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_74",
         "logos-module": "logos-module_102",
-        "logos-nix": "logos-nix_757",
+        "logos-nix": "logos-nix_758",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -1327,7 +1327,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_107",
-        "logos-nix": "logos-nix_796",
+        "logos-nix": "logos-nix_797",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -1362,7 +1362,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_79",
         "logos-module": "logos-module_108",
-        "logos-nix": "logos-nix_801",
+        "logos-nix": "logos-nix_802",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -1557,7 +1557,7 @@
     },
     "logos-container_10": {
       "inputs": {
-        "logos-nix": "logos-nix_561",
+        "logos-nix": "logos-nix_562",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -1585,7 +1585,7 @@
     },
     "logos-container_11": {
       "inputs": {
-        "logos-nix": "logos-nix_730",
+        "logos-nix": "logos-nix_731",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -1613,7 +1613,7 @@
     },
     "logos-container_12": {
       "inputs": {
-        "logos-nix": "logos-nix_732",
+        "logos-nix": "logos-nix_733",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -1641,7 +1641,7 @@
     },
     "logos-container_13": {
       "inputs": {
-        "logos-nix": "logos-nix_734",
+        "logos-nix": "logos-nix_735",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -1670,7 +1670,7 @@
     },
     "logos-container_14": {
       "inputs": {
-        "logos-nix": "logos-nix_858",
+        "logos-nix": "logos-nix_859",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -1697,7 +1697,7 @@
     },
     "logos-container_15": {
       "inputs": {
-        "logos-nix": "logos-nix_861",
+        "logos-nix": "logos-nix_862",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -1833,7 +1833,7 @@
     },
     "logos-container_6": {
       "inputs": {
-        "logos-nix": "logos-nix_430",
+        "logos-nix": "logos-nix_431",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -1861,7 +1861,7 @@
     },
     "logos-container_7": {
       "inputs": {
-        "logos-nix": "logos-nix_432",
+        "logos-nix": "logos-nix_433",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -1889,7 +1889,7 @@
     },
     "logos-container_8": {
       "inputs": {
-        "logos-nix": "logos-nix_434",
+        "logos-nix": "logos-nix_435",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -1918,7 +1918,7 @@
     },
     "logos-container_9": {
       "inputs": {
-        "logos-nix": "logos-nix_558",
+        "logos-nix": "logos-nix_559",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -2626,7 +2626,7 @@
     "logos-cpp-sdk_29": {
       "inputs": {
         "logos-lidl": "logos-lidl_14",
-        "logos-nix": "logos-nix_296",
+        "logos-nix": "logos-nix_297",
         "logos-protocol": [
           "package_downloader",
           "logos-module-builder",
@@ -2687,7 +2687,7 @@
     "logos-cpp-sdk_30": {
       "inputs": {
         "logos-lidl": "logos-lidl_17",
-        "logos-nix": "logos-nix_305",
+        "logos-nix": "logos-nix_306",
         "logos-protocol": [
           "package_downloader",
           "logos-module-builder",
@@ -2723,7 +2723,7 @@
     },
     "logos-cpp-sdk_31": {
       "inputs": {
-        "logos-nix": "logos-nix_314",
+        "logos-nix": "logos-nix_315",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -2754,7 +2754,7 @@
     },
     "logos-cpp-sdk_32": {
       "inputs": {
-        "logos-nix": "logos-nix_323",
+        "logos-nix": "logos-nix_324",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -2786,7 +2786,7 @@
     },
     "logos-cpp-sdk_33": {
       "inputs": {
-        "logos-nix": "logos-nix_325",
+        "logos-nix": "logos-nix_326",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -2820,7 +2820,7 @@
     },
     "logos-cpp-sdk_34": {
       "inputs": {
-        "logos-nix": "logos-nix_328",
+        "logos-nix": "logos-nix_329",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -2853,7 +2853,7 @@
     },
     "logos-cpp-sdk_35": {
       "inputs": {
-        "logos-nix": "logos-nix_356",
+        "logos-nix": "logos-nix_357",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -2882,7 +2882,7 @@
     },
     "logos-cpp-sdk_36": {
       "inputs": {
-        "logos-nix": "logos-nix_358",
+        "logos-nix": "logos-nix_359",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -2914,7 +2914,7 @@
     },
     "logos-cpp-sdk_37": {
       "inputs": {
-        "logos-nix": "logos-nix_367",
+        "logos-nix": "logos-nix_368",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -2947,7 +2947,7 @@
     },
     "logos-cpp-sdk_38": {
       "inputs": {
-        "logos-nix": "logos-nix_369",
+        "logos-nix": "logos-nix_370",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -2982,7 +2982,7 @@
     },
     "logos-cpp-sdk_39": {
       "inputs": {
-        "logos-nix": "logos-nix_372",
+        "logos-nix": "logos-nix_373",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -3047,7 +3047,7 @@
     },
     "logos-cpp-sdk_40": {
       "inputs": {
-        "logos-nix": "logos-nix_400",
+        "logos-nix": "logos-nix_401",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -3117,7 +3117,7 @@
     "logos-cpp-sdk_42": {
       "inputs": {
         "logos-lidl": "logos-lidl_20",
-        "logos-nix": "logos-nix_428",
+        "logos-nix": "logos-nix_429",
         "logos-protocol": "logos-protocol_13",
         "nixpkgs": [
           "package_downloader",
@@ -3144,7 +3144,7 @@
     },
     "logos-cpp-sdk_43": {
       "inputs": {
-        "logos-nix": "logos-nix_437",
+        "logos-nix": "logos-nix_438",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -3173,7 +3173,7 @@
     },
     "logos-cpp-sdk_44": {
       "inputs": {
-        "logos-nix": "logos-nix_444",
+        "logos-nix": "logos-nix_445",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -3205,7 +3205,7 @@
     },
     "logos-cpp-sdk_45": {
       "inputs": {
-        "logos-nix": "logos-nix_453",
+        "logos-nix": "logos-nix_454",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -3238,7 +3238,7 @@
     },
     "logos-cpp-sdk_46": {
       "inputs": {
-        "logos-nix": "logos-nix_455",
+        "logos-nix": "logos-nix_456",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -3273,7 +3273,7 @@
     },
     "logos-cpp-sdk_47": {
       "inputs": {
-        "logos-nix": "logos-nix_458",
+        "logos-nix": "logos-nix_459",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -3307,7 +3307,7 @@
     },
     "logos-cpp-sdk_48": {
       "inputs": {
-        "logos-nix": "logos-nix_486",
+        "logos-nix": "logos-nix_487",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -3337,7 +3337,7 @@
     },
     "logos-cpp-sdk_49": {
       "inputs": {
-        "logos-nix": "logos-nix_488",
+        "logos-nix": "logos-nix_489",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -3403,7 +3403,7 @@
     },
     "logos-cpp-sdk_50": {
       "inputs": {
-        "logos-nix": "logos-nix_497",
+        "logos-nix": "logos-nix_498",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -3437,7 +3437,7 @@
     },
     "logos-cpp-sdk_51": {
       "inputs": {
-        "logos-nix": "logos-nix_499",
+        "logos-nix": "logos-nix_500",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -3473,7 +3473,7 @@
     },
     "logos-cpp-sdk_52": {
       "inputs": {
-        "logos-nix": "logos-nix_502",
+        "logos-nix": "logos-nix_503",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -3508,7 +3508,7 @@
     },
     "logos-cpp-sdk_53": {
       "inputs": {
-        "logos-nix": "logos-nix_530",
+        "logos-nix": "logos-nix_531",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -3581,7 +3581,7 @@
     "logos-cpp-sdk_55": {
       "inputs": {
         "logos-lidl": "logos-lidl_21",
-        "logos-nix": "logos-nix_559",
+        "logos-nix": "logos-nix_560",
         "logos-protocol": [
           "package_downloader",
           "logos-module-builder",
@@ -3651,7 +3651,7 @@
     "logos-cpp-sdk_57": {
       "inputs": {
         "logos-lidl": "logos-lidl_27",
-        "logos-nix": "logos-nix_596",
+        "logos-nix": "logos-nix_597",
         "logos-protocol": [
           "package_manager",
           "logos-module-builder",
@@ -3682,7 +3682,7 @@
     "logos-cpp-sdk_58": {
       "inputs": {
         "logos-lidl": "logos-lidl_30",
-        "logos-nix": "logos-nix_605",
+        "logos-nix": "logos-nix_606",
         "logos-protocol": [
           "package_manager",
           "logos-module-builder",
@@ -3718,7 +3718,7 @@
     },
     "logos-cpp-sdk_59": {
       "inputs": {
-        "logos-nix": "logos-nix_614",
+        "logos-nix": "logos-nix_615",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -3781,7 +3781,7 @@
     },
     "logos-cpp-sdk_60": {
       "inputs": {
-        "logos-nix": "logos-nix_623",
+        "logos-nix": "logos-nix_624",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -3813,7 +3813,7 @@
     },
     "logos-cpp-sdk_61": {
       "inputs": {
-        "logos-nix": "logos-nix_625",
+        "logos-nix": "logos-nix_626",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -3847,7 +3847,7 @@
     },
     "logos-cpp-sdk_62": {
       "inputs": {
-        "logos-nix": "logos-nix_628",
+        "logos-nix": "logos-nix_629",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -3880,7 +3880,7 @@
     },
     "logos-cpp-sdk_63": {
       "inputs": {
-        "logos-nix": "logos-nix_656",
+        "logos-nix": "logos-nix_657",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -3909,7 +3909,7 @@
     },
     "logos-cpp-sdk_64": {
       "inputs": {
-        "logos-nix": "logos-nix_658",
+        "logos-nix": "logos-nix_659",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -3941,7 +3941,7 @@
     },
     "logos-cpp-sdk_65": {
       "inputs": {
-        "logos-nix": "logos-nix_667",
+        "logos-nix": "logos-nix_668",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -3974,7 +3974,7 @@
     },
     "logos-cpp-sdk_66": {
       "inputs": {
-        "logos-nix": "logos-nix_669",
+        "logos-nix": "logos-nix_670",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -4009,7 +4009,7 @@
     },
     "logos-cpp-sdk_67": {
       "inputs": {
-        "logos-nix": "logos-nix_672",
+        "logos-nix": "logos-nix_673",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -4043,7 +4043,7 @@
     },
     "logos-cpp-sdk_68": {
       "inputs": {
-        "logos-nix": "logos-nix_700",
+        "logos-nix": "logos-nix_701",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -4141,7 +4141,7 @@
     "logos-cpp-sdk_70": {
       "inputs": {
         "logos-lidl": "logos-lidl_33",
-        "logos-nix": "logos-nix_728",
+        "logos-nix": "logos-nix_729",
         "logos-protocol": "logos-protocol_22",
         "nixpkgs": [
           "package_manager",
@@ -4168,7 +4168,7 @@
     },
     "logos-cpp-sdk_71": {
       "inputs": {
-        "logos-nix": "logos-nix_737",
+        "logos-nix": "logos-nix_738",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -4197,7 +4197,7 @@
     },
     "logos-cpp-sdk_72": {
       "inputs": {
-        "logos-nix": "logos-nix_744",
+        "logos-nix": "logos-nix_745",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -4229,7 +4229,7 @@
     },
     "logos-cpp-sdk_73": {
       "inputs": {
-        "logos-nix": "logos-nix_753",
+        "logos-nix": "logos-nix_754",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -4262,7 +4262,7 @@
     },
     "logos-cpp-sdk_74": {
       "inputs": {
-        "logos-nix": "logos-nix_755",
+        "logos-nix": "logos-nix_756",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -4297,7 +4297,7 @@
     },
     "logos-cpp-sdk_75": {
       "inputs": {
-        "logos-nix": "logos-nix_758",
+        "logos-nix": "logos-nix_759",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -4331,7 +4331,7 @@
     },
     "logos-cpp-sdk_76": {
       "inputs": {
-        "logos-nix": "logos-nix_786",
+        "logos-nix": "logos-nix_787",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -4361,7 +4361,7 @@
     },
     "logos-cpp-sdk_77": {
       "inputs": {
-        "logos-nix": "logos-nix_788",
+        "logos-nix": "logos-nix_789",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -4394,7 +4394,7 @@
     },
     "logos-cpp-sdk_78": {
       "inputs": {
-        "logos-nix": "logos-nix_797",
+        "logos-nix": "logos-nix_798",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -4428,7 +4428,7 @@
     },
     "logos-cpp-sdk_79": {
       "inputs": {
-        "logos-nix": "logos-nix_799",
+        "logos-nix": "logos-nix_800",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -4495,7 +4495,7 @@
     },
     "logos-cpp-sdk_80": {
       "inputs": {
-        "logos-nix": "logos-nix_802",
+        "logos-nix": "logos-nix_803",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -4530,7 +4530,7 @@
     },
     "logos-cpp-sdk_81": {
       "inputs": {
-        "logos-nix": "logos-nix_830",
+        "logos-nix": "logos-nix_831",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -4603,7 +4603,7 @@
     "logos-cpp-sdk_83": {
       "inputs": {
         "logos-lidl": "logos-lidl_34",
-        "logos-nix": "logos-nix_859",
+        "logos-nix": "logos-nix_860",
         "logos-protocol": [
           "package_manager",
           "logos-module-builder",
@@ -4735,7 +4735,7 @@
     },
     "logos-design-system_10": {
       "inputs": {
-        "logos-nix": "logos-nix_368",
+        "logos-nix": "logos-nix_369",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -4768,7 +4768,7 @@
     },
     "logos-design-system_11": {
       "inputs": {
-        "logos-nix": "logos-nix_429",
+        "logos-nix": "logos-nix_430",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -4794,7 +4794,7 @@
     },
     "logos-design-system_12": {
       "inputs": {
-        "logos-nix": "logos-nix_454",
+        "logos-nix": "logos-nix_455",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -4827,7 +4827,7 @@
     },
     "logos-design-system_13": {
       "inputs": {
-        "logos-nix": "logos-nix_487",
+        "logos-nix": "logos-nix_488",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -4857,7 +4857,7 @@
     },
     "logos-design-system_14": {
       "inputs": {
-        "logos-nix": "logos-nix_498",
+        "logos-nix": "logos-nix_499",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -4891,7 +4891,7 @@
     },
     "logos-design-system_15": {
       "inputs": {
-        "logos-nix": "logos-nix_624",
+        "logos-nix": "logos-nix_625",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -4923,7 +4923,7 @@
     },
     "logos-design-system_16": {
       "inputs": {
-        "logos-nix": "logos-nix_657",
+        "logos-nix": "logos-nix_658",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -4952,7 +4952,7 @@
     },
     "logos-design-system_17": {
       "inputs": {
-        "logos-nix": "logos-nix_668",
+        "logos-nix": "logos-nix_669",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -4985,7 +4985,7 @@
     },
     "logos-design-system_18": {
       "inputs": {
-        "logos-nix": "logos-nix_729",
+        "logos-nix": "logos-nix_730",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -5011,7 +5011,7 @@
     },
     "logos-design-system_19": {
       "inputs": {
-        "logos-nix": "logos-nix_754",
+        "logos-nix": "logos-nix_755",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -5072,7 +5072,7 @@
     },
     "logos-design-system_20": {
       "inputs": {
-        "logos-nix": "logos-nix_787",
+        "logos-nix": "logos-nix_788",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -5102,7 +5102,7 @@
     },
     "logos-design-system_21": {
       "inputs": {
-        "logos-nix": "logos-nix_798",
+        "logos-nix": "logos-nix_799",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -5287,7 +5287,7 @@
     },
     "logos-design-system_8": {
       "inputs": {
-        "logos-nix": "logos-nix_324",
+        "logos-nix": "logos-nix_325",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -5319,7 +5319,7 @@
     },
     "logos-design-system_9": {
       "inputs": {
-        "logos-nix": "logos-nix_357",
+        "logos-nix": "logos-nix_358",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -5386,7 +5386,7 @@
         "logos-capability-module": "logos-capability-module_21",
         "logos-cpp-sdk": "logos-cpp-sdk_39",
         "logos-module": "logos-module_55",
-        "logos-nix": "logos-nix_374",
+        "logos-nix": "logos-nix_375",
         "logos-package-manager": "logos-package-manager_17",
         "nixpkgs": [
           "package_downloader",
@@ -5427,7 +5427,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_55",
         "logos-module": "logos-module_74",
         "logos-module-loader": "logos-module-loader_4",
-        "logos-nix": "logos-nix_563",
+        "logos-nix": "logos-nix_564",
         "logos-package-manager": "logos-package-manager_27",
         "logos-protocol": "logos-protocol_14",
         "logos-qt-sdk": "logos-qt-sdk_11",
@@ -5460,7 +5460,7 @@
         "logos-capability-module": "logos-capability-module_25",
         "logos-cpp-sdk": "logos-cpp-sdk_47",
         "logos-module": "logos-module_66",
-        "logos-nix": "logos-nix_460",
+        "logos-nix": "logos-nix_461",
         "logos-package-manager": "logos-package-manager_21",
         "nixpkgs": [
           "package_downloader",
@@ -5497,7 +5497,7 @@
         "logos-capability-module": "logos-capability-module_26",
         "logos-cpp-sdk": "logos-cpp-sdk_53",
         "logos-module": "logos-module_73",
-        "logos-nix": "logos-nix_532",
+        "logos-nix": "logos-nix_533",
         "logos-package-manager": "logos-package-manager_25",
         "nixpkgs": [
           "package_downloader",
@@ -5532,7 +5532,7 @@
         "logos-capability-module": "logos-capability-module_28",
         "logos-cpp-sdk": "logos-cpp-sdk_52",
         "logos-module": "logos-module_72",
-        "logos-nix": "logos-nix_504",
+        "logos-nix": "logos-nix_505",
         "logos-package-manager": "logos-package-manager_23",
         "nixpkgs": [
           "package_downloader",
@@ -5570,7 +5570,7 @@
         "logos-capability-module": "logos-capability-module_32",
         "logos-cpp-sdk": "logos-cpp-sdk_62",
         "logos-module": "logos-module_86",
-        "logos-nix": "logos-nix_630",
+        "logos-nix": "logos-nix_631",
         "logos-package-manager": "logos-package-manager_29",
         "nixpkgs": [
           "package_manager",
@@ -5606,7 +5606,7 @@
         "logos-capability-module": "logos-capability-module_33",
         "logos-cpp-sdk": "logos-cpp-sdk_68",
         "logos-module": "logos-module_93",
-        "logos-nix": "logos-nix_702",
+        "logos-nix": "logos-nix_703",
         "logos-package-manager": "logos-package-manager_33",
         "nixpkgs": [
           "package_manager",
@@ -5640,7 +5640,7 @@
         "logos-capability-module": "logos-capability-module_35",
         "logos-cpp-sdk": "logos-cpp-sdk_67",
         "logos-module": "logos-module_92",
-        "logos-nix": "logos-nix_674",
+        "logos-nix": "logos-nix_675",
         "logos-package-manager": "logos-package-manager_31",
         "nixpkgs": [
           "package_manager",
@@ -5681,7 +5681,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_83",
         "logos-module": "logos-module_111",
         "logos-module-loader": "logos-module-loader_6",
-        "logos-nix": "logos-nix_863",
+        "logos-nix": "logos-nix_864",
         "logos-package-manager": "logos-package-manager_41",
         "logos-protocol": "logos-protocol_23",
         "logos-qt-sdk": "logos-qt-sdk_18",
@@ -5714,7 +5714,7 @@
         "logos-capability-module": "logos-capability-module_39",
         "logos-cpp-sdk": "logos-cpp-sdk_75",
         "logos-module": "logos-module_103",
-        "logos-nix": "logos-nix_760",
+        "logos-nix": "logos-nix_761",
         "logos-package-manager": "logos-package-manager_35",
         "nixpkgs": [
           "package_manager",
@@ -5784,7 +5784,7 @@
         "logos-capability-module": "logos-capability-module_40",
         "logos-cpp-sdk": "logos-cpp-sdk_81",
         "logos-module": "logos-module_110",
-        "logos-nix": "logos-nix_832",
+        "logos-nix": "logos-nix_833",
         "logos-package-manager": "logos-package-manager_39",
         "nixpkgs": [
           "package_manager",
@@ -5819,7 +5819,7 @@
         "logos-capability-module": "logos-capability-module_42",
         "logos-cpp-sdk": "logos-cpp-sdk_80",
         "logos-module": "logos-module_109",
-        "logos-nix": "logos-nix_804",
+        "logos-nix": "logos-nix_805",
         "logos-package-manager": "logos-package-manager_37",
         "nixpkgs": [
           "package_manager",
@@ -6036,7 +6036,7 @@
         "logos-capability-module": "logos-capability-module_18",
         "logos-cpp-sdk": "logos-cpp-sdk_34",
         "logos-module": "logos-module_49",
-        "logos-nix": "logos-nix_330",
+        "logos-nix": "logos-nix_331",
         "logos-package-manager": "logos-package-manager_15",
         "nixpkgs": [
           "package_downloader",
@@ -6072,7 +6072,7 @@
         "logos-capability-module": "logos-capability-module_19",
         "logos-cpp-sdk": "logos-cpp-sdk_40",
         "logos-module": "logos-module_56",
-        "logos-nix": "logos-nix_402",
+        "logos-nix": "logos-nix_403",
         "logos-package-manager": "logos-package-manager_19",
         "nixpkgs": [
           "package_downloader",
@@ -7467,7 +7467,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_31",
         "logos-module": "logos-module_44",
-        "logos-nix": "logos-nix_316",
+        "logos-nix": "logos-nix_317",
         "logos-plugin-core": "logos-plugin-core_10",
         "logos-plugin-qt": "logos-plugin-qt_10",
         "logos-standalone-app": "logos-standalone-app_10",
@@ -7505,7 +7505,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_36",
         "logos-module": "logos-module_50",
-        "logos-nix": "logos-nix_360",
+        "logos-nix": "logos-nix_361",
         "logos-plugin-core": "logos-plugin-core_11",
         "logos-plugin-qt": "logos-plugin-qt_11",
         "logos-standalone-app": "logos-standalone-app_11",
@@ -7544,7 +7544,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_43",
         "logos-module": "logos-module_58",
-        "logos-nix": "logos-nix_439",
+        "logos-nix": "logos-nix_440",
         "logos-plugin-core": "logos-plugin-core_12",
         "logos-plugin-qt": "logos-plugin-qt_12",
         "logos-standalone-app": "logos-standalone-app_12",
@@ -7580,7 +7580,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_44",
         "logos-module": "logos-module_61",
-        "logos-nix": "logos-nix_446",
+        "logos-nix": "logos-nix_447",
         "logos-plugin-core": "logos-plugin-core_13",
         "logos-plugin-qt": "logos-plugin-qt_13",
         "logos-standalone-app": "logos-standalone-app_13",
@@ -7619,7 +7619,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_49",
         "logos-module": "logos-module_67",
-        "logos-nix": "logos-nix_490",
+        "logos-nix": "logos-nix_491",
         "logos-plugin-core": "logos-plugin-core_14",
         "logos-plugin-qt": "logos-plugin-qt_14",
         "logos-standalone-app": "logos-standalone-app_14",
@@ -7659,7 +7659,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_57",
         "logos-module": "logos-module_75",
-        "logos-nix": "logos-nix_598",
+        "logos-nix": "logos-nix_599",
         "logos-plugin-core": "logos-plugin-core_15",
         "logos-plugin-qt": "logos-plugin-qt_15",
         "logos-protocol": "logos-protocol_19",
@@ -7695,7 +7695,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_58",
         "logos-module": "logos-module_78",
-        "logos-nix": "logos-nix_607",
+        "logos-nix": "logos-nix_608",
         "logos-plugin-core": "logos-plugin-core_16",
         "logos-plugin-qt": "logos-plugin-qt_16",
         "logos-protocol": "logos-protocol_20",
@@ -7734,7 +7734,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_59",
         "logos-module": "logos-module_81",
-        "logos-nix": "logos-nix_616",
+        "logos-nix": "logos-nix_617",
         "logos-plugin-core": "logos-plugin-core_17",
         "logos-plugin-qt": "logos-plugin-qt_17",
         "logos-standalone-app": "logos-standalone-app_17",
@@ -7772,7 +7772,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_64",
         "logos-module": "logos-module_87",
-        "logos-nix": "logos-nix_660",
+        "logos-nix": "logos-nix_661",
         "logos-plugin-core": "logos-plugin-core_18",
         "logos-plugin-qt": "logos-plugin-qt_18",
         "logos-standalone-app": "logos-standalone-app_18",
@@ -7811,7 +7811,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_71",
         "logos-module": "logos-module_95",
-        "logos-nix": "logos-nix_739",
+        "logos-nix": "logos-nix_740",
         "logos-plugin-core": "logos-plugin-core_19",
         "logos-plugin-qt": "logos-plugin-qt_19",
         "logos-standalone-app": "logos-standalone-app_19",
@@ -7885,7 +7885,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_72",
         "logos-module": "logos-module_98",
-        "logos-nix": "logos-nix_746",
+        "logos-nix": "logos-nix_747",
         "logos-plugin-core": "logos-plugin-core_20",
         "logos-plugin-qt": "logos-plugin-qt_20",
         "logos-standalone-app": "logos-standalone-app_20",
@@ -7924,7 +7924,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_77",
         "logos-module": "logos-module_104",
-        "logos-nix": "logos-nix_790",
+        "logos-nix": "logos-nix_791",
         "logos-plugin-core": "logos-plugin-core_21",
         "logos-plugin-qt": "logos-plugin-qt_21",
         "logos-standalone-app": "logos-standalone-app_21",
@@ -8151,7 +8151,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_29",
         "logos-module": "logos-module_38",
-        "logos-nix": "logos-nix_298",
+        "logos-nix": "logos-nix_299",
         "logos-plugin-core": "logos-plugin-core_8",
         "logos-plugin-qt": "logos-plugin-qt_8",
         "logos-protocol": "logos-protocol_10",
@@ -8187,7 +8187,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_30",
         "logos-module": "logos-module_41",
-        "logos-nix": "logos-nix_307",
+        "logos-nix": "logos-nix_308",
         "logos-plugin-core": "logos-plugin-core_9",
         "logos-plugin-qt": "logos-plugin-qt_9",
         "logos-protocol": "logos-protocol_11",
@@ -8280,7 +8280,7 @@
     "logos-module-loader_3": {
       "inputs": {
         "logos-container": "logos-container_8",
-        "logos-nix": "logos-nix_435",
+        "logos-nix": "logos-nix_436",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -8309,7 +8309,7 @@
     "logos-module-loader_4": {
       "inputs": {
         "logos-container": "logos-container_10",
-        "logos-nix": "logos-nix_562",
+        "logos-nix": "logos-nix_563",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -8337,7 +8337,7 @@
     "logos-module-loader_5": {
       "inputs": {
         "logos-container": "logos-container_13",
-        "logos-nix": "logos-nix_735",
+        "logos-nix": "logos-nix_736",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -8366,7 +8366,7 @@
     "logos-module-loader_6": {
       "inputs": {
         "logos-container": "logos-container_15",
-        "logos-nix": "logos-nix_862",
+        "logos-nix": "logos-nix_863",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -8425,7 +8425,7 @@
     },
     "logos-module_100": {
       "inputs": {
-        "logos-nix": "logos-nix_749",
+        "logos-nix": "logos-nix_750",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -8458,7 +8458,7 @@
     },
     "logos-module_101": {
       "inputs": {
-        "logos-nix": "logos-nix_751",
+        "logos-nix": "logos-nix_752",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -8492,7 +8492,7 @@
     },
     "logos-module_102": {
       "inputs": {
-        "logos-nix": "logos-nix_756",
+        "logos-nix": "logos-nix_757",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -8527,7 +8527,7 @@
     },
     "logos-module_103": {
       "inputs": {
-        "logos-nix": "logos-nix_759",
+        "logos-nix": "logos-nix_760",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -8561,7 +8561,7 @@
     },
     "logos-module_104": {
       "inputs": {
-        "logos-nix": "logos-nix_789",
+        "logos-nix": "logos-nix_790",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -8594,7 +8594,7 @@
     },
     "logos-module_105": {
       "inputs": {
-        "logos-nix": "logos-nix_791",
+        "logos-nix": "logos-nix_792",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -8628,7 +8628,7 @@
     },
     "logos-module_106": {
       "inputs": {
-        "logos-nix": "logos-nix_793",
+        "logos-nix": "logos-nix_794",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -8662,7 +8662,7 @@
     },
     "logos-module_107": {
       "inputs": {
-        "logos-nix": "logos-nix_795",
+        "logos-nix": "logos-nix_796",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -8697,7 +8697,7 @@
     },
     "logos-module_108": {
       "inputs": {
-        "logos-nix": "logos-nix_800",
+        "logos-nix": "logos-nix_801",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -8733,7 +8733,7 @@
     },
     "logos-module_109": {
       "inputs": {
-        "logos-nix": "logos-nix_803",
+        "logos-nix": "logos-nix_804",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -8801,7 +8801,7 @@
     },
     "logos-module_110": {
       "inputs": {
-        "logos-nix": "logos-nix_831",
+        "logos-nix": "logos-nix_832",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -8832,7 +8832,7 @@
     },
     "logos-module_111": {
       "inputs": {
-        "logos-nix": "logos-nix_860",
+        "logos-nix": "logos-nix_861",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -9730,7 +9730,7 @@
     },
     "logos-module_38": {
       "inputs": {
-        "logos-nix": "logos-nix_297",
+        "logos-nix": "logos-nix_298",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -9755,7 +9755,7 @@
     },
     "logos-module_39": {
       "inputs": {
-        "logos-nix": "logos-nix_299",
+        "logos-nix": "logos-nix_300",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -9808,7 +9808,7 @@
     },
     "logos-module_40": {
       "inputs": {
-        "logos-nix": "logos-nix_301",
+        "logos-nix": "logos-nix_302",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -9834,7 +9834,7 @@
     },
     "logos-module_41": {
       "inputs": {
-        "logos-nix": "logos-nix_306",
+        "logos-nix": "logos-nix_307",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -9862,7 +9862,7 @@
     },
     "logos-module_42": {
       "inputs": {
-        "logos-nix": "logos-nix_308",
+        "logos-nix": "logos-nix_309",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -9891,7 +9891,7 @@
     },
     "logos-module_43": {
       "inputs": {
-        "logos-nix": "logos-nix_310",
+        "logos-nix": "logos-nix_311",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -9920,7 +9920,7 @@
     },
     "logos-module_44": {
       "inputs": {
-        "logos-nix": "logos-nix_315",
+        "logos-nix": "logos-nix_316",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -9951,7 +9951,7 @@
     },
     "logos-module_45": {
       "inputs": {
-        "logos-nix": "logos-nix_317",
+        "logos-nix": "logos-nix_318",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -9983,7 +9983,7 @@
     },
     "logos-module_46": {
       "inputs": {
-        "logos-nix": "logos-nix_319",
+        "logos-nix": "logos-nix_320",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10015,7 +10015,7 @@
     },
     "logos-module_47": {
       "inputs": {
-        "logos-nix": "logos-nix_321",
+        "logos-nix": "logos-nix_322",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10048,7 +10048,7 @@
     },
     "logos-module_48": {
       "inputs": {
-        "logos-nix": "logos-nix_326",
+        "logos-nix": "logos-nix_327",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10082,7 +10082,7 @@
     },
     "logos-module_49": {
       "inputs": {
-        "logos-nix": "logos-nix_329",
+        "logos-nix": "logos-nix_330",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10143,7 +10143,7 @@
     },
     "logos-module_50": {
       "inputs": {
-        "logos-nix": "logos-nix_359",
+        "logos-nix": "logos-nix_360",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10175,7 +10175,7 @@
     },
     "logos-module_51": {
       "inputs": {
-        "logos-nix": "logos-nix_361",
+        "logos-nix": "logos-nix_362",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10208,7 +10208,7 @@
     },
     "logos-module_52": {
       "inputs": {
-        "logos-nix": "logos-nix_363",
+        "logos-nix": "logos-nix_364",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10241,7 +10241,7 @@
     },
     "logos-module_53": {
       "inputs": {
-        "logos-nix": "logos-nix_365",
+        "logos-nix": "logos-nix_366",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10275,7 +10275,7 @@
     },
     "logos-module_54": {
       "inputs": {
-        "logos-nix": "logos-nix_370",
+        "logos-nix": "logos-nix_371",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10310,7 +10310,7 @@
     },
     "logos-module_55": {
       "inputs": {
-        "logos-nix": "logos-nix_373",
+        "logos-nix": "logos-nix_374",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10344,7 +10344,7 @@
     },
     "logos-module_56": {
       "inputs": {
-        "logos-nix": "logos-nix_401",
+        "logos-nix": "logos-nix_402",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10374,7 +10374,7 @@
     },
     "logos-module_57": {
       "inputs": {
-        "logos-nix": "logos-nix_433",
+        "logos-nix": "logos-nix_434",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10402,7 +10402,7 @@
     },
     "logos-module_58": {
       "inputs": {
-        "logos-nix": "logos-nix_438",
+        "logos-nix": "logos-nix_439",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10431,7 +10431,7 @@
     },
     "logos-module_59": {
       "inputs": {
-        "logos-nix": "logos-nix_440",
+        "logos-nix": "logos-nix_441",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10489,7 +10489,7 @@
     },
     "logos-module_60": {
       "inputs": {
-        "logos-nix": "logos-nix_442",
+        "logos-nix": "logos-nix_443",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10519,7 +10519,7 @@
     },
     "logos-module_61": {
       "inputs": {
-        "logos-nix": "logos-nix_445",
+        "logos-nix": "logos-nix_446",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10551,7 +10551,7 @@
     },
     "logos-module_62": {
       "inputs": {
-        "logos-nix": "logos-nix_447",
+        "logos-nix": "logos-nix_448",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10584,7 +10584,7 @@
     },
     "logos-module_63": {
       "inputs": {
-        "logos-nix": "logos-nix_449",
+        "logos-nix": "logos-nix_450",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10617,7 +10617,7 @@
     },
     "logos-module_64": {
       "inputs": {
-        "logos-nix": "logos-nix_451",
+        "logos-nix": "logos-nix_452",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10651,7 +10651,7 @@
     },
     "logos-module_65": {
       "inputs": {
-        "logos-nix": "logos-nix_456",
+        "logos-nix": "logos-nix_457",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10686,7 +10686,7 @@
     },
     "logos-module_66": {
       "inputs": {
-        "logos-nix": "logos-nix_459",
+        "logos-nix": "logos-nix_460",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10720,7 +10720,7 @@
     },
     "logos-module_67": {
       "inputs": {
-        "logos-nix": "logos-nix_489",
+        "logos-nix": "logos-nix_490",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10753,7 +10753,7 @@
     },
     "logos-module_68": {
       "inputs": {
-        "logos-nix": "logos-nix_491",
+        "logos-nix": "logos-nix_492",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10787,7 +10787,7 @@
     },
     "logos-module_69": {
       "inputs": {
-        "logos-nix": "logos-nix_493",
+        "logos-nix": "logos-nix_494",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10851,7 +10851,7 @@
     },
     "logos-module_70": {
       "inputs": {
-        "logos-nix": "logos-nix_495",
+        "logos-nix": "logos-nix_496",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10886,7 +10886,7 @@
     },
     "logos-module_71": {
       "inputs": {
-        "logos-nix": "logos-nix_500",
+        "logos-nix": "logos-nix_501",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10922,7 +10922,7 @@
     },
     "logos-module_72": {
       "inputs": {
-        "logos-nix": "logos-nix_503",
+        "logos-nix": "logos-nix_504",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10957,7 +10957,7 @@
     },
     "logos-module_73": {
       "inputs": {
-        "logos-nix": "logos-nix_531",
+        "logos-nix": "logos-nix_532",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -10988,7 +10988,7 @@
     },
     "logos-module_74": {
       "inputs": {
-        "logos-nix": "logos-nix_560",
+        "logos-nix": "logos-nix_561",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -11015,7 +11015,7 @@
     },
     "logos-module_75": {
       "inputs": {
-        "logos-nix": "logos-nix_597",
+        "logos-nix": "logos-nix_598",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -11040,7 +11040,7 @@
     },
     "logos-module_76": {
       "inputs": {
-        "logos-nix": "logos-nix_599",
+        "logos-nix": "logos-nix_600",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -11066,7 +11066,7 @@
     },
     "logos-module_77": {
       "inputs": {
-        "logos-nix": "logos-nix_601",
+        "logos-nix": "logos-nix_602",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -11092,7 +11092,7 @@
     },
     "logos-module_78": {
       "inputs": {
-        "logos-nix": "logos-nix_606",
+        "logos-nix": "logos-nix_607",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -11120,7 +11120,7 @@
     },
     "logos-module_79": {
       "inputs": {
-        "logos-nix": "logos-nix_608",
+        "logos-nix": "logos-nix_609",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -11180,7 +11180,7 @@
     },
     "logos-module_80": {
       "inputs": {
-        "logos-nix": "logos-nix_610",
+        "logos-nix": "logos-nix_611",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -11209,7 +11209,7 @@
     },
     "logos-module_81": {
       "inputs": {
-        "logos-nix": "logos-nix_615",
+        "logos-nix": "logos-nix_616",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -11240,7 +11240,7 @@
     },
     "logos-module_82": {
       "inputs": {
-        "logos-nix": "logos-nix_617",
+        "logos-nix": "logos-nix_618",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -11272,7 +11272,7 @@
     },
     "logos-module_83": {
       "inputs": {
-        "logos-nix": "logos-nix_619",
+        "logos-nix": "logos-nix_620",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -11304,7 +11304,7 @@
     },
     "logos-module_84": {
       "inputs": {
-        "logos-nix": "logos-nix_621",
+        "logos-nix": "logos-nix_622",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -11337,7 +11337,7 @@
     },
     "logos-module_85": {
       "inputs": {
-        "logos-nix": "logos-nix_626",
+        "logos-nix": "logos-nix_627",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -11371,7 +11371,7 @@
     },
     "logos-module_86": {
       "inputs": {
-        "logos-nix": "logos-nix_629",
+        "logos-nix": "logos-nix_630",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -11404,7 +11404,7 @@
     },
     "logos-module_87": {
       "inputs": {
-        "logos-nix": "logos-nix_659",
+        "logos-nix": "logos-nix_660",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -11436,7 +11436,7 @@
     },
     "logos-module_88": {
       "inputs": {
-        "logos-nix": "logos-nix_661",
+        "logos-nix": "logos-nix_662",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -11469,7 +11469,7 @@
     },
     "logos-module_89": {
       "inputs": {
-        "logos-nix": "logos-nix_663",
+        "logos-nix": "logos-nix_664",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -11533,7 +11533,7 @@
     },
     "logos-module_90": {
       "inputs": {
-        "logos-nix": "logos-nix_665",
+        "logos-nix": "logos-nix_666",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -11567,7 +11567,7 @@
     },
     "logos-module_91": {
       "inputs": {
-        "logos-nix": "logos-nix_670",
+        "logos-nix": "logos-nix_671",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -11602,7 +11602,7 @@
     },
     "logos-module_92": {
       "inputs": {
-        "logos-nix": "logos-nix_673",
+        "logos-nix": "logos-nix_674",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -11636,7 +11636,7 @@
     },
     "logos-module_93": {
       "inputs": {
-        "logos-nix": "logos-nix_701",
+        "logos-nix": "logos-nix_702",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -11666,7 +11666,7 @@
     },
     "logos-module_94": {
       "inputs": {
-        "logos-nix": "logos-nix_733",
+        "logos-nix": "logos-nix_734",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -11694,7 +11694,7 @@
     },
     "logos-module_95": {
       "inputs": {
-        "logos-nix": "logos-nix_738",
+        "logos-nix": "logos-nix_739",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -11723,7 +11723,7 @@
     },
     "logos-module_96": {
       "inputs": {
-        "logos-nix": "logos-nix_740",
+        "logos-nix": "logos-nix_741",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -11753,7 +11753,7 @@
     },
     "logos-module_97": {
       "inputs": {
-        "logos-nix": "logos-nix_742",
+        "logos-nix": "logos-nix_743",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -11783,7 +11783,7 @@
     },
     "logos-module_98": {
       "inputs": {
-        "logos-nix": "logos-nix_745",
+        "logos-nix": "logos-nix_746",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -11815,7 +11815,7 @@
     },
     "logos-module_99": {
       "inputs": {
-        "logos-nix": "logos-nix_747",
+        "logos-nix": "logos-nix_748",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -15775,11 +15775,11 @@
         "nixpkgs": "nixpkgs_296"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15793,24 +15793,6 @@
         "nixpkgs": "nixpkgs_297"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_298": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_298"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -15824,9 +15806,9 @@
         "type": "github"
       }
     },
-    "logos-nix_299": {
+    "logos-nix_298": {
       "inputs": {
-        "nixpkgs": "nixpkgs_299"
+        "nixpkgs": "nixpkgs_298"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -15834,6 +15816,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_299": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_299"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15883,24 +15883,6 @@
         "nixpkgs": "nixpkgs_300"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_301": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_301"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -15914,9 +15896,9 @@
         "type": "github"
       }
     },
-    "logos-nix_302": {
+    "logos-nix_301": {
       "inputs": {
-        "nixpkgs": "nixpkgs_302"
+        "nixpkgs": "nixpkgs_301"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -15924,6 +15906,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_302": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_302"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15991,11 +15991,11 @@
         "nixpkgs": "nixpkgs_306"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16009,24 +16009,6 @@
         "nixpkgs": "nixpkgs_307"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_308": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_308"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -16040,9 +16022,9 @@
         "type": "github"
       }
     },
-    "logos-nix_309": {
+    "logos-nix_308": {
       "inputs": {
-        "nixpkgs": "nixpkgs_309"
+        "nixpkgs": "nixpkgs_308"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -16050,6 +16032,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_309": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_309"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16081,11 +16081,11 @@
         "nixpkgs": "nixpkgs_310"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16099,11 +16099,11 @@
         "nixpkgs": "nixpkgs_311"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16171,11 +16171,11 @@
         "nixpkgs": "nixpkgs_315"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16189,11 +16189,11 @@
         "nixpkgs": "nixpkgs_316"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16207,24 +16207,6 @@
         "nixpkgs": "nixpkgs_317"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_318": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_318"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -16238,9 +16220,9 @@
         "type": "github"
       }
     },
-    "logos-nix_319": {
+    "logos-nix_318": {
       "inputs": {
-        "nixpkgs": "nixpkgs_319"
+        "nixpkgs": "nixpkgs_318"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -16248,6 +16230,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_319": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_319"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16279,11 +16279,11 @@
         "nixpkgs": "nixpkgs_320"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16297,11 +16297,11 @@
         "nixpkgs": "nixpkgs_321"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16333,11 +16333,11 @@
         "nixpkgs": "nixpkgs_323"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16351,11 +16351,11 @@
         "nixpkgs": "nixpkgs_324"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16423,11 +16423,11 @@
         "nixpkgs": "nixpkgs_328"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16441,11 +16441,11 @@
         "nixpkgs": "nixpkgs_329"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16477,11 +16477,11 @@
         "nixpkgs": "nixpkgs_330"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16513,11 +16513,11 @@
         "nixpkgs": "nixpkgs_332"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16603,24 +16603,6 @@
         "nixpkgs": "nixpkgs_337"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_338": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_338"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -16634,9 +16616,9 @@
         "type": "github"
       }
     },
-    "logos-nix_339": {
+    "logos-nix_338": {
       "inputs": {
-        "nixpkgs": "nixpkgs_339"
+        "nixpkgs": "nixpkgs_338"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -16644,6 +16626,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_339": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_339"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16693,11 +16693,11 @@
         "nixpkgs": "nixpkgs_341"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16729,11 +16729,11 @@
         "nixpkgs": "nixpkgs_343"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16765,11 +16765,11 @@
         "nixpkgs": "nixpkgs_345"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16801,11 +16801,11 @@
         "nixpkgs": "nixpkgs_347"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16837,11 +16837,11 @@
         "nixpkgs": "nixpkgs_349"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16927,11 +16927,11 @@
         "nixpkgs": "nixpkgs_353"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16945,11 +16945,11 @@
         "nixpkgs": "nixpkgs_354"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16981,11 +16981,11 @@
         "nixpkgs": "nixpkgs_356"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16999,24 +16999,6 @@
         "nixpkgs": "nixpkgs_357"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_358": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_358"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -17030,9 +17012,9 @@
         "type": "github"
       }
     },
-    "logos-nix_359": {
+    "logos-nix_358": {
       "inputs": {
-        "nixpkgs": "nixpkgs_359"
+        "nixpkgs": "nixpkgs_358"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -17040,6 +17022,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_359": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_359"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17071,11 +17071,11 @@
         "nixpkgs": "nixpkgs_360"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17089,11 +17089,11 @@
         "nixpkgs": "nixpkgs_361"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17107,11 +17107,11 @@
         "nixpkgs": "nixpkgs_362"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17125,24 +17125,6 @@
         "nixpkgs": "nixpkgs_363"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_364": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_364"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -17156,9 +17138,9 @@
         "type": "github"
       }
     },
-    "logos-nix_365": {
+    "logos-nix_364": {
       "inputs": {
-        "nixpkgs": "nixpkgs_365"
+        "nixpkgs": "nixpkgs_364"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -17166,6 +17148,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_365": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_365"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17197,11 +17197,11 @@
         "nixpkgs": "nixpkgs_367"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17215,11 +17215,11 @@
         "nixpkgs": "nixpkgs_368"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17305,24 +17305,6 @@
         "nixpkgs": "nixpkgs_372"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_373": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_373"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -17336,9 +17318,9 @@
         "type": "github"
       }
     },
-    "logos-nix_374": {
+    "logos-nix_373": {
       "inputs": {
-        "nixpkgs": "nixpkgs_374"
+        "nixpkgs": "nixpkgs_373"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -17346,6 +17328,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_374": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_374"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17377,11 +17377,11 @@
         "nixpkgs": "nixpkgs_376"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17485,24 +17485,6 @@
         "nixpkgs": "nixpkgs_381"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_382": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_382"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -17516,9 +17498,9 @@
         "type": "github"
       }
     },
-    "logos-nix_383": {
+    "logos-nix_382": {
       "inputs": {
-        "nixpkgs": "nixpkgs_383"
+        "nixpkgs": "nixpkgs_382"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -17526,6 +17508,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_383": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_383"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17557,11 +17557,11 @@
         "nixpkgs": "nixpkgs_385"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17593,11 +17593,11 @@
         "nixpkgs": "nixpkgs_387"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17629,11 +17629,11 @@
         "nixpkgs": "nixpkgs_389"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17683,11 +17683,11 @@
         "nixpkgs": "nixpkgs_391"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17719,11 +17719,11 @@
         "nixpkgs": "nixpkgs_393"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17791,11 +17791,11 @@
         "nixpkgs": "nixpkgs_397"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17809,11 +17809,11 @@
         "nixpkgs": "nixpkgs_398"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17881,24 +17881,6 @@
         "nixpkgs": "nixpkgs_400"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_401": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_401"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -17912,9 +17894,9 @@
         "type": "github"
       }
     },
-    "logos-nix_402": {
+    "logos-nix_401": {
       "inputs": {
-        "nixpkgs": "nixpkgs_402"
+        "nixpkgs": "nixpkgs_401"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -17922,6 +17904,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_402": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_402"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17953,11 +17953,11 @@
         "nixpkgs": "nixpkgs_404"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18043,11 +18043,11 @@
         "nixpkgs": "nixpkgs_409"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18079,11 +18079,11 @@
         "nixpkgs": "nixpkgs_410"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18097,11 +18097,11 @@
         "nixpkgs": "nixpkgs_411"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18133,11 +18133,11 @@
         "nixpkgs": "nixpkgs_413"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18169,11 +18169,11 @@
         "nixpkgs": "nixpkgs_415"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18205,11 +18205,11 @@
         "nixpkgs": "nixpkgs_417"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18241,11 +18241,11 @@
         "nixpkgs": "nixpkgs_419"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18295,11 +18295,11 @@
         "nixpkgs": "nixpkgs_421"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18367,11 +18367,11 @@
         "nixpkgs": "nixpkgs_425"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18385,11 +18385,11 @@
         "nixpkgs": "nixpkgs_426"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18421,11 +18421,11 @@
         "nixpkgs": "nixpkgs_428"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18439,11 +18439,11 @@
         "nixpkgs": "nixpkgs_429"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18475,11 +18475,11 @@
         "nixpkgs": "nixpkgs_430"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18529,11 +18529,11 @@
         "nixpkgs": "nixpkgs_433"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18547,11 +18547,11 @@
         "nixpkgs": "nixpkgs_434"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18619,11 +18619,11 @@
         "nixpkgs": "nixpkgs_438"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18637,11 +18637,11 @@
         "nixpkgs": "nixpkgs_439"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18673,11 +18673,11 @@
         "nixpkgs": "nixpkgs_440"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18691,24 +18691,6 @@
         "nixpkgs": "nixpkgs_441"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_442": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_442"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -18722,9 +18704,9 @@
         "type": "github"
       }
     },
-    "logos-nix_443": {
+    "logos-nix_442": {
       "inputs": {
-        "nixpkgs": "nixpkgs_443"
+        "nixpkgs": "nixpkgs_442"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -18732,6 +18714,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_443": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_443"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18763,11 +18763,11 @@
         "nixpkgs": "nixpkgs_445"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18781,11 +18781,11 @@
         "nixpkgs": "nixpkgs_446"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18799,24 +18799,6 @@
         "nixpkgs": "nixpkgs_447"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_448": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_448"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -18830,9 +18812,9 @@
         "type": "github"
       }
     },
-    "logos-nix_449": {
+    "logos-nix_448": {
       "inputs": {
-        "nixpkgs": "nixpkgs_449"
+        "nixpkgs": "nixpkgs_448"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -18840,6 +18822,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_449": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_449"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18871,11 +18871,11 @@
         "nixpkgs": "nixpkgs_450"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18889,11 +18889,11 @@
         "nixpkgs": "nixpkgs_451"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18925,11 +18925,11 @@
         "nixpkgs": "nixpkgs_453"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18943,11 +18943,11 @@
         "nixpkgs": "nixpkgs_454"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19015,11 +19015,11 @@
         "nixpkgs": "nixpkgs_458"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19033,11 +19033,11 @@
         "nixpkgs": "nixpkgs_459"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19069,11 +19069,11 @@
         "nixpkgs": "nixpkgs_460"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19105,11 +19105,11 @@
         "nixpkgs": "nixpkgs_462"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19195,24 +19195,6 @@
         "nixpkgs": "nixpkgs_467"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_468": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_468"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -19226,9 +19208,9 @@
         "type": "github"
       }
     },
-    "logos-nix_469": {
+    "logos-nix_468": {
       "inputs": {
-        "nixpkgs": "nixpkgs_469"
+        "nixpkgs": "nixpkgs_468"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -19236,6 +19218,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_469": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_469"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19285,11 +19285,11 @@
         "nixpkgs": "nixpkgs_471"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19321,11 +19321,11 @@
         "nixpkgs": "nixpkgs_473"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19357,11 +19357,11 @@
         "nixpkgs": "nixpkgs_475"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19393,11 +19393,11 @@
         "nixpkgs": "nixpkgs_477"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19429,11 +19429,11 @@
         "nixpkgs": "nixpkgs_479"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19519,11 +19519,11 @@
         "nixpkgs": "nixpkgs_483"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19537,11 +19537,11 @@
         "nixpkgs": "nixpkgs_484"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19573,11 +19573,11 @@
         "nixpkgs": "nixpkgs_486"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19591,24 +19591,6 @@
         "nixpkgs": "nixpkgs_487"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_488": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_488"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -19622,9 +19604,9 @@
         "type": "github"
       }
     },
-    "logos-nix_489": {
+    "logos-nix_488": {
       "inputs": {
-        "nixpkgs": "nixpkgs_489"
+        "nixpkgs": "nixpkgs_488"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -19632,6 +19614,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_489": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_489"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19663,11 +19663,11 @@
         "nixpkgs": "nixpkgs_490"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19681,11 +19681,11 @@
         "nixpkgs": "nixpkgs_491"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19699,11 +19699,11 @@
         "nixpkgs": "nixpkgs_492"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19717,24 +19717,6 @@
         "nixpkgs": "nixpkgs_493"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_494": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_494"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -19748,9 +19730,9 @@
         "type": "github"
       }
     },
-    "logos-nix_495": {
+    "logos-nix_494": {
       "inputs": {
-        "nixpkgs": "nixpkgs_495"
+        "nixpkgs": "nixpkgs_494"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -19758,6 +19740,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_495": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_495"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19789,11 +19789,11 @@
         "nixpkgs": "nixpkgs_497"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19807,11 +19807,11 @@
         "nixpkgs": "nixpkgs_498"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19915,24 +19915,6 @@
         "nixpkgs": "nixpkgs_502"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_503": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_503"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -19946,9 +19928,9 @@
         "type": "github"
       }
     },
-    "logos-nix_504": {
+    "logos-nix_503": {
       "inputs": {
-        "nixpkgs": "nixpkgs_504"
+        "nixpkgs": "nixpkgs_503"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -19956,6 +19938,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_504": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_504"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19987,11 +19987,11 @@
         "nixpkgs": "nixpkgs_506"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20095,24 +20095,6 @@
         "nixpkgs": "nixpkgs_511"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_512": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_512"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -20126,9 +20108,9 @@
         "type": "github"
       }
     },
-    "logos-nix_513": {
+    "logos-nix_512": {
       "inputs": {
-        "nixpkgs": "nixpkgs_513"
+        "nixpkgs": "nixpkgs_512"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -20136,6 +20118,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_513": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_513"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20167,11 +20167,11 @@
         "nixpkgs": "nixpkgs_515"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20203,11 +20203,11 @@
         "nixpkgs": "nixpkgs_517"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20239,11 +20239,11 @@
         "nixpkgs": "nixpkgs_519"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20293,11 +20293,11 @@
         "nixpkgs": "nixpkgs_521"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20329,11 +20329,11 @@
         "nixpkgs": "nixpkgs_523"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20401,11 +20401,11 @@
         "nixpkgs": "nixpkgs_527"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20419,11 +20419,11 @@
         "nixpkgs": "nixpkgs_528"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20473,24 +20473,6 @@
         "nixpkgs": "nixpkgs_530"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_531": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_531"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -20504,9 +20486,9 @@
         "type": "github"
       }
     },
-    "logos-nix_532": {
+    "logos-nix_531": {
       "inputs": {
-        "nixpkgs": "nixpkgs_532"
+        "nixpkgs": "nixpkgs_531"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -20514,6 +20496,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_532": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_532"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20545,11 +20545,11 @@
         "nixpkgs": "nixpkgs_534"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20635,11 +20635,11 @@
         "nixpkgs": "nixpkgs_539"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20671,11 +20671,11 @@
         "nixpkgs": "nixpkgs_540"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20689,11 +20689,11 @@
         "nixpkgs": "nixpkgs_541"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20725,11 +20725,11 @@
         "nixpkgs": "nixpkgs_543"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20761,11 +20761,11 @@
         "nixpkgs": "nixpkgs_545"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20797,11 +20797,11 @@
         "nixpkgs": "nixpkgs_547"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20833,11 +20833,11 @@
         "nixpkgs": "nixpkgs_549"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20887,11 +20887,11 @@
         "nixpkgs": "nixpkgs_551"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20959,11 +20959,11 @@
         "nixpkgs": "nixpkgs_555"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20977,11 +20977,11 @@
         "nixpkgs": "nixpkgs_556"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21013,11 +21013,11 @@
         "nixpkgs": "nixpkgs_558"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21067,11 +21067,11 @@
         "nixpkgs": "nixpkgs_560"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21085,11 +21085,11 @@
         "nixpkgs": "nixpkgs_561"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21157,11 +21157,11 @@
         "nixpkgs": "nixpkgs_565"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21229,11 +21229,11 @@
         "nixpkgs": "nixpkgs_569"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21283,11 +21283,11 @@
         "nixpkgs": "nixpkgs_571"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21301,24 +21301,6 @@
         "nixpkgs": "nixpkgs_572"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_573": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_573"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -21332,9 +21314,9 @@
         "type": "github"
       }
     },
-    "logos-nix_574": {
+    "logos-nix_573": {
       "inputs": {
-        "nixpkgs": "nixpkgs_574"
+        "nixpkgs": "nixpkgs_573"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -21342,6 +21324,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_574": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_574"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21373,11 +21373,11 @@
         "nixpkgs": "nixpkgs_576"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21409,11 +21409,11 @@
         "nixpkgs": "nixpkgs_578"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21463,11 +21463,11 @@
         "nixpkgs": "nixpkgs_580"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21499,11 +21499,11 @@
         "nixpkgs": "nixpkgs_582"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21535,11 +21535,11 @@
         "nixpkgs": "nixpkgs_584"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21607,11 +21607,11 @@
         "nixpkgs": "nixpkgs_588"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21625,11 +21625,11 @@
         "nixpkgs": "nixpkgs_589"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21679,11 +21679,11 @@
         "nixpkgs": "nixpkgs_591"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21697,24 +21697,6 @@
         "nixpkgs": "nixpkgs_592"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_593": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_593"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -21728,9 +21710,9 @@
         "type": "github"
       }
     },
-    "logos-nix_594": {
+    "logos-nix_593": {
       "inputs": {
-        "nixpkgs": "nixpkgs_594"
+        "nixpkgs": "nixpkgs_593"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -21738,6 +21720,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_594": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_594"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21769,11 +21769,11 @@
         "nixpkgs": "nixpkgs_596"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21787,24 +21787,6 @@
         "nixpkgs": "nixpkgs_597"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_598": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_598"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -21818,9 +21800,9 @@
         "type": "github"
       }
     },
-    "logos-nix_599": {
+    "logos-nix_598": {
       "inputs": {
-        "nixpkgs": "nixpkgs_599"
+        "nixpkgs": "nixpkgs_598"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -21828,6 +21810,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_599": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_599"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21877,24 +21877,6 @@
         "nixpkgs": "nixpkgs_600"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_601": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_601"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -21908,9 +21890,9 @@
         "type": "github"
       }
     },
-    "logos-nix_602": {
+    "logos-nix_601": {
       "inputs": {
-        "nixpkgs": "nixpkgs_602"
+        "nixpkgs": "nixpkgs_601"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -21918,6 +21900,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_602": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_602"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21985,11 +21985,11 @@
         "nixpkgs": "nixpkgs_606"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22003,24 +22003,6 @@
         "nixpkgs": "nixpkgs_607"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_608": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_608"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -22034,9 +22016,9 @@
         "type": "github"
       }
     },
-    "logos-nix_609": {
+    "logos-nix_608": {
       "inputs": {
-        "nixpkgs": "nixpkgs_609"
+        "nixpkgs": "nixpkgs_608"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -22044,6 +22026,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_609": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_609"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22075,11 +22075,11 @@
         "nixpkgs": "nixpkgs_610"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22093,11 +22093,11 @@
         "nixpkgs": "nixpkgs_611"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22165,11 +22165,11 @@
         "nixpkgs": "nixpkgs_615"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22183,11 +22183,11 @@
         "nixpkgs": "nixpkgs_616"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22201,24 +22201,6 @@
         "nixpkgs": "nixpkgs_617"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_618": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_618"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -22232,9 +22214,9 @@
         "type": "github"
       }
     },
-    "logos-nix_619": {
+    "logos-nix_618": {
       "inputs": {
-        "nixpkgs": "nixpkgs_619"
+        "nixpkgs": "nixpkgs_618"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -22242,6 +22224,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_619": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_619"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22273,11 +22273,11 @@
         "nixpkgs": "nixpkgs_620"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22291,11 +22291,11 @@
         "nixpkgs": "nixpkgs_621"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22327,11 +22327,11 @@
         "nixpkgs": "nixpkgs_623"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22345,11 +22345,11 @@
         "nixpkgs": "nixpkgs_624"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22417,11 +22417,11 @@
         "nixpkgs": "nixpkgs_628"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22435,11 +22435,11 @@
         "nixpkgs": "nixpkgs_629"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22471,11 +22471,11 @@
         "nixpkgs": "nixpkgs_630"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22507,11 +22507,11 @@
         "nixpkgs": "nixpkgs_632"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22597,24 +22597,6 @@
         "nixpkgs": "nixpkgs_637"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_638": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_638"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -22628,9 +22610,9 @@
         "type": "github"
       }
     },
-    "logos-nix_639": {
+    "logos-nix_638": {
       "inputs": {
-        "nixpkgs": "nixpkgs_639"
+        "nixpkgs": "nixpkgs_638"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -22638,6 +22620,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_639": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_639"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22687,11 +22687,11 @@
         "nixpkgs": "nixpkgs_641"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22723,11 +22723,11 @@
         "nixpkgs": "nixpkgs_643"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22759,11 +22759,11 @@
         "nixpkgs": "nixpkgs_645"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22795,11 +22795,11 @@
         "nixpkgs": "nixpkgs_647"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22831,11 +22831,11 @@
         "nixpkgs": "nixpkgs_649"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22921,11 +22921,11 @@
         "nixpkgs": "nixpkgs_653"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22939,11 +22939,11 @@
         "nixpkgs": "nixpkgs_654"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22975,11 +22975,11 @@
         "nixpkgs": "nixpkgs_656"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22993,24 +22993,6 @@
         "nixpkgs": "nixpkgs_657"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_658": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_658"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -23024,9 +23006,9 @@
         "type": "github"
       }
     },
-    "logos-nix_659": {
+    "logos-nix_658": {
       "inputs": {
-        "nixpkgs": "nixpkgs_659"
+        "nixpkgs": "nixpkgs_658"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -23034,6 +23016,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_659": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_659"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23065,11 +23065,11 @@
         "nixpkgs": "nixpkgs_660"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23083,11 +23083,11 @@
         "nixpkgs": "nixpkgs_661"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23101,11 +23101,11 @@
         "nixpkgs": "nixpkgs_662"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23119,24 +23119,6 @@
         "nixpkgs": "nixpkgs_663"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_664": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_664"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -23150,9 +23132,9 @@
         "type": "github"
       }
     },
-    "logos-nix_665": {
+    "logos-nix_664": {
       "inputs": {
-        "nixpkgs": "nixpkgs_665"
+        "nixpkgs": "nixpkgs_664"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -23160,6 +23142,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_665": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_665"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23191,11 +23191,11 @@
         "nixpkgs": "nixpkgs_667"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23209,11 +23209,11 @@
         "nixpkgs": "nixpkgs_668"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23299,24 +23299,6 @@
         "nixpkgs": "nixpkgs_672"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_673": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_673"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -23330,9 +23312,9 @@
         "type": "github"
       }
     },
-    "logos-nix_674": {
+    "logos-nix_673": {
       "inputs": {
-        "nixpkgs": "nixpkgs_674"
+        "nixpkgs": "nixpkgs_673"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -23340,6 +23322,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_674": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_674"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23371,11 +23371,11 @@
         "nixpkgs": "nixpkgs_676"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23479,24 +23479,6 @@
         "nixpkgs": "nixpkgs_681"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_682": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_682"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -23510,9 +23492,9 @@
         "type": "github"
       }
     },
-    "logos-nix_683": {
+    "logos-nix_682": {
       "inputs": {
-        "nixpkgs": "nixpkgs_683"
+        "nixpkgs": "nixpkgs_682"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -23520,6 +23502,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_683": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_683"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23551,11 +23551,11 @@
         "nixpkgs": "nixpkgs_685"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23587,11 +23587,11 @@
         "nixpkgs": "nixpkgs_687"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23623,11 +23623,11 @@
         "nixpkgs": "nixpkgs_689"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23677,11 +23677,11 @@
         "nixpkgs": "nixpkgs_691"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23713,11 +23713,11 @@
         "nixpkgs": "nixpkgs_693"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23785,11 +23785,11 @@
         "nixpkgs": "nixpkgs_697"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23803,11 +23803,11 @@
         "nixpkgs": "nixpkgs_698"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23875,24 +23875,6 @@
         "nixpkgs": "nixpkgs_700"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_701": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_701"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -23906,9 +23888,9 @@
         "type": "github"
       }
     },
-    "logos-nix_702": {
+    "logos-nix_701": {
       "inputs": {
-        "nixpkgs": "nixpkgs_702"
+        "nixpkgs": "nixpkgs_701"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -23916,6 +23898,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_702": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_702"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23947,11 +23947,11 @@
         "nixpkgs": "nixpkgs_704"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -24037,11 +24037,11 @@
         "nixpkgs": "nixpkgs_709"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24073,11 +24073,11 @@
         "nixpkgs": "nixpkgs_710"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -24091,11 +24091,11 @@
         "nixpkgs": "nixpkgs_711"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24127,11 +24127,11 @@
         "nixpkgs": "nixpkgs_713"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -24163,11 +24163,11 @@
         "nixpkgs": "nixpkgs_715"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24199,11 +24199,11 @@
         "nixpkgs": "nixpkgs_717"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -24235,11 +24235,11 @@
         "nixpkgs": "nixpkgs_719"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24289,11 +24289,11 @@
         "nixpkgs": "nixpkgs_721"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -24361,11 +24361,11 @@
         "nixpkgs": "nixpkgs_725"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24379,11 +24379,11 @@
         "nixpkgs": "nixpkgs_726"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -24415,11 +24415,11 @@
         "nixpkgs": "nixpkgs_728"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24433,11 +24433,11 @@
         "nixpkgs": "nixpkgs_729"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -24469,11 +24469,11 @@
         "nixpkgs": "nixpkgs_730"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24523,11 +24523,11 @@
         "nixpkgs": "nixpkgs_733"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -24541,11 +24541,11 @@
         "nixpkgs": "nixpkgs_734"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24613,11 +24613,11 @@
         "nixpkgs": "nixpkgs_738"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -24631,11 +24631,11 @@
         "nixpkgs": "nixpkgs_739"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24667,11 +24667,11 @@
         "nixpkgs": "nixpkgs_740"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -24685,24 +24685,6 @@
         "nixpkgs": "nixpkgs_741"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_742": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_742"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -24716,9 +24698,9 @@
         "type": "github"
       }
     },
-    "logos-nix_743": {
+    "logos-nix_742": {
       "inputs": {
-        "nixpkgs": "nixpkgs_743"
+        "nixpkgs": "nixpkgs_742"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -24726,6 +24708,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_743": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_743"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24757,11 +24757,11 @@
         "nixpkgs": "nixpkgs_745"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -24775,11 +24775,11 @@
         "nixpkgs": "nixpkgs_746"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24793,24 +24793,6 @@
         "nixpkgs": "nixpkgs_747"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_748": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_748"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -24824,9 +24806,9 @@
         "type": "github"
       }
     },
-    "logos-nix_749": {
+    "logos-nix_748": {
       "inputs": {
-        "nixpkgs": "nixpkgs_749"
+        "nixpkgs": "nixpkgs_748"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -24834,6 +24816,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_749": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_749"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -24865,11 +24865,11 @@
         "nixpkgs": "nixpkgs_750"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24883,11 +24883,11 @@
         "nixpkgs": "nixpkgs_751"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -24919,11 +24919,11 @@
         "nixpkgs": "nixpkgs_753"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24937,11 +24937,11 @@
         "nixpkgs": "nixpkgs_754"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25009,11 +25009,11 @@
         "nixpkgs": "nixpkgs_758"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25027,11 +25027,11 @@
         "nixpkgs": "nixpkgs_759"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25063,11 +25063,11 @@
         "nixpkgs": "nixpkgs_760"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25099,11 +25099,11 @@
         "nixpkgs": "nixpkgs_762"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25189,24 +25189,6 @@
         "nixpkgs": "nixpkgs_767"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_768": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_768"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -25220,9 +25202,9 @@
         "type": "github"
       }
     },
-    "logos-nix_769": {
+    "logos-nix_768": {
       "inputs": {
-        "nixpkgs": "nixpkgs_769"
+        "nixpkgs": "nixpkgs_768"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -25230,6 +25212,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_769": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_769"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25279,11 +25279,11 @@
         "nixpkgs": "nixpkgs_771"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25315,11 +25315,11 @@
         "nixpkgs": "nixpkgs_773"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25351,11 +25351,11 @@
         "nixpkgs": "nixpkgs_775"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25387,11 +25387,11 @@
         "nixpkgs": "nixpkgs_777"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25423,11 +25423,11 @@
         "nixpkgs": "nixpkgs_779"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25513,11 +25513,11 @@
         "nixpkgs": "nixpkgs_783"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25531,11 +25531,11 @@
         "nixpkgs": "nixpkgs_784"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25567,11 +25567,11 @@
         "nixpkgs": "nixpkgs_786"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25585,24 +25585,6 @@
         "nixpkgs": "nixpkgs_787"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_788": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_788"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -25616,9 +25598,9 @@
         "type": "github"
       }
     },
-    "logos-nix_789": {
+    "logos-nix_788": {
       "inputs": {
-        "nixpkgs": "nixpkgs_789"
+        "nixpkgs": "nixpkgs_788"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -25626,6 +25608,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_789": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_789"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25657,11 +25657,11 @@
         "nixpkgs": "nixpkgs_790"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25675,11 +25675,11 @@
         "nixpkgs": "nixpkgs_791"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25693,11 +25693,11 @@
         "nixpkgs": "nixpkgs_792"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25711,24 +25711,6 @@
         "nixpkgs": "nixpkgs_793"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_794": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_794"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -25742,9 +25724,9 @@
         "type": "github"
       }
     },
-    "logos-nix_795": {
+    "logos-nix_794": {
       "inputs": {
-        "nixpkgs": "nixpkgs_795"
+        "nixpkgs": "nixpkgs_794"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -25752,6 +25734,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_795": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_795"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25783,11 +25783,11 @@
         "nixpkgs": "nixpkgs_797"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25801,11 +25801,11 @@
         "nixpkgs": "nixpkgs_798"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25909,24 +25909,6 @@
         "nixpkgs": "nixpkgs_802"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_803": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_803"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -25940,9 +25922,9 @@
         "type": "github"
       }
     },
-    "logos-nix_804": {
+    "logos-nix_803": {
       "inputs": {
-        "nixpkgs": "nixpkgs_804"
+        "nixpkgs": "nixpkgs_803"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -25950,6 +25932,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_804": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_804"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25981,11 +25981,11 @@
         "nixpkgs": "nixpkgs_806"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26089,24 +26089,6 @@
         "nixpkgs": "nixpkgs_811"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_812": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_812"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -26120,9 +26102,9 @@
         "type": "github"
       }
     },
-    "logos-nix_813": {
+    "logos-nix_812": {
       "inputs": {
-        "nixpkgs": "nixpkgs_813"
+        "nixpkgs": "nixpkgs_812"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -26130,6 +26112,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_813": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_813"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26161,11 +26161,11 @@
         "nixpkgs": "nixpkgs_815"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26197,11 +26197,11 @@
         "nixpkgs": "nixpkgs_817"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26233,11 +26233,11 @@
         "nixpkgs": "nixpkgs_819"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26287,11 +26287,11 @@
         "nixpkgs": "nixpkgs_821"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26323,11 +26323,11 @@
         "nixpkgs": "nixpkgs_823"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26395,11 +26395,11 @@
         "nixpkgs": "nixpkgs_827"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26413,11 +26413,11 @@
         "nixpkgs": "nixpkgs_828"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26467,24 +26467,6 @@
         "nixpkgs": "nixpkgs_830"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_831": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_831"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -26498,9 +26480,9 @@
         "type": "github"
       }
     },
-    "logos-nix_832": {
+    "logos-nix_831": {
       "inputs": {
-        "nixpkgs": "nixpkgs_832"
+        "nixpkgs": "nixpkgs_831"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -26508,6 +26490,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_832": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_832"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26539,11 +26539,11 @@
         "nixpkgs": "nixpkgs_834"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26629,11 +26629,11 @@
         "nixpkgs": "nixpkgs_839"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26665,11 +26665,11 @@
         "nixpkgs": "nixpkgs_840"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26683,11 +26683,11 @@
         "nixpkgs": "nixpkgs_841"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26719,11 +26719,11 @@
         "nixpkgs": "nixpkgs_843"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26755,11 +26755,11 @@
         "nixpkgs": "nixpkgs_845"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26791,11 +26791,11 @@
         "nixpkgs": "nixpkgs_847"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26827,11 +26827,11 @@
         "nixpkgs": "nixpkgs_849"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26881,11 +26881,11 @@
         "nixpkgs": "nixpkgs_851"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26953,11 +26953,11 @@
         "nixpkgs": "nixpkgs_855"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26971,11 +26971,11 @@
         "nixpkgs": "nixpkgs_856"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -27007,11 +27007,11 @@
         "nixpkgs": "nixpkgs_858"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -27061,11 +27061,11 @@
         "nixpkgs": "nixpkgs_860"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -27079,11 +27079,11 @@
         "nixpkgs": "nixpkgs_861"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -27151,11 +27151,11 @@
         "nixpkgs": "nixpkgs_865"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -27223,11 +27223,11 @@
         "nixpkgs": "nixpkgs_869"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -27277,11 +27277,11 @@
         "nixpkgs": "nixpkgs_871"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -27295,24 +27295,6 @@
         "nixpkgs": "nixpkgs_872"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_873": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_873"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -27326,9 +27308,9 @@
         "type": "github"
       }
     },
-    "logos-nix_874": {
+    "logos-nix_873": {
       "inputs": {
-        "nixpkgs": "nixpkgs_874"
+        "nixpkgs": "nixpkgs_873"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -27336,6 +27318,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_874": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_874"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -27367,11 +27367,11 @@
         "nixpkgs": "nixpkgs_876"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -27403,11 +27403,11 @@
         "nixpkgs": "nixpkgs_878"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -27457,11 +27457,11 @@
         "nixpkgs": "nixpkgs_880"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -27493,11 +27493,11 @@
         "nixpkgs": "nixpkgs_882"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -27529,11 +27529,11 @@
         "nixpkgs": "nixpkgs_884"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -27601,11 +27601,11 @@
         "nixpkgs": "nixpkgs_888"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -27619,11 +27619,11 @@
         "nixpkgs": "nixpkgs_889"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -27673,11 +27673,11 @@
         "nixpkgs": "nixpkgs_891"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -27691,11 +27691,11 @@
         "nixpkgs": "nixpkgs_892"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -27743,6 +27743,24 @@
     "logos-nix_895": {
       "inputs": {
         "nixpkgs": "nixpkgs_895"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_896": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_896"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -27991,8 +28009,8 @@
     },
     "logos-package-downloader": {
       "inputs": {
-        "logos-nix": "logos-nix_591",
-        "logos-package": "logos-package_71",
+        "logos-nix": "logos-nix_592",
+        "logos-package": "logos-package_72",
         "nix-bundle-appimage": "nix-bundle-appimage_29",
         "nix-bundle-dir": "nix-bundle-dir_100",
         "nixpkgs": [
@@ -28211,8 +28229,8 @@
     },
     "logos-package-manager_15": {
       "inputs": {
-        "logos-nix": "logos-nix_331",
-        "logos-package": "logos-package_36",
+        "logos-nix": "logos-nix_332",
+        "logos-package": "logos-package_37",
         "nix-bundle-appimage": "nix-bundle-appimage_15",
         "nix-bundle-dir": "nix-bundle-dir_51",
         "nixpkgs": [
@@ -28247,8 +28265,8 @@
     },
     "logos-package-manager_16": {
       "inputs": {
-        "logos-nix": "logos-nix_348",
-        "logos-package": "logos-package_39",
+        "logos-nix": "logos-nix_349",
+        "logos-package": "logos-package_40",
         "nix-bundle-appimage": "nix-bundle-appimage_16",
         "nix-bundle-dir": "nix-bundle-dir_55",
         "nixpkgs": [
@@ -28282,8 +28300,8 @@
     },
     "logos-package-manager_17": {
       "inputs": {
-        "logos-nix": "logos-nix_375",
-        "logos-package": "logos-package_41",
+        "logos-nix": "logos-nix_376",
+        "logos-package": "logos-package_42",
         "nix-bundle-appimage": "nix-bundle-appimage_17",
         "nix-bundle-dir": "nix-bundle-dir_58",
         "nixpkgs": [
@@ -28319,8 +28337,8 @@
     },
     "logos-package-manager_18": {
       "inputs": {
-        "logos-nix": "logos-nix_392",
-        "logos-package": "logos-package_44",
+        "logos-nix": "logos-nix_393",
+        "logos-package": "logos-package_45",
         "nix-bundle-appimage": "nix-bundle-appimage_18",
         "nix-bundle-dir": "nix-bundle-dir_62",
         "nixpkgs": [
@@ -28355,8 +28373,8 @@
     },
     "logos-package-manager_19": {
       "inputs": {
-        "logos-nix": "logos-nix_403",
-        "logos-package": "logos-package_46",
+        "logos-nix": "logos-nix_404",
+        "logos-package": "logos-package_47",
         "nix-bundle-appimage": "nix-bundle-appimage_19",
         "nix-bundle-dir": "nix-bundle-dir_65",
         "nixpkgs": [
@@ -28422,8 +28440,8 @@
     },
     "logos-package-manager_20": {
       "inputs": {
-        "logos-nix": "logos-nix_420",
-        "logos-package": "logos-package_49",
+        "logos-nix": "logos-nix_421",
+        "logos-package": "logos-package_50",
         "nix-bundle-appimage": "nix-bundle-appimage_20",
         "nix-bundle-dir": "nix-bundle-dir_69",
         "nixpkgs": [
@@ -28454,8 +28472,8 @@
     },
     "logos-package-manager_21": {
       "inputs": {
-        "logos-nix": "logos-nix_461",
-        "logos-package": "logos-package_51",
+        "logos-nix": "logos-nix_462",
+        "logos-package": "logos-package_52",
         "nix-bundle-appimage": "nix-bundle-appimage_21",
         "nix-bundle-dir": "nix-bundle-dir_72",
         "nixpkgs": [
@@ -28491,8 +28509,8 @@
     },
     "logos-package-manager_22": {
       "inputs": {
-        "logos-nix": "logos-nix_478",
-        "logos-package": "logos-package_54",
+        "logos-nix": "logos-nix_479",
+        "logos-package": "logos-package_55",
         "nix-bundle-appimage": "nix-bundle-appimage_22",
         "nix-bundle-dir": "nix-bundle-dir_76",
         "nixpkgs": [
@@ -28527,8 +28545,8 @@
     },
     "logos-package-manager_23": {
       "inputs": {
-        "logos-nix": "logos-nix_505",
-        "logos-package": "logos-package_56",
+        "logos-nix": "logos-nix_506",
+        "logos-package": "logos-package_57",
         "nix-bundle-appimage": "nix-bundle-appimage_23",
         "nix-bundle-dir": "nix-bundle-dir_79",
         "nixpkgs": [
@@ -28565,8 +28583,8 @@
     },
     "logos-package-manager_24": {
       "inputs": {
-        "logos-nix": "logos-nix_522",
-        "logos-package": "logos-package_59",
+        "logos-nix": "logos-nix_523",
+        "logos-package": "logos-package_60",
         "nix-bundle-appimage": "nix-bundle-appimage_24",
         "nix-bundle-dir": "nix-bundle-dir_83",
         "nixpkgs": [
@@ -28602,8 +28620,8 @@
     },
     "logos-package-manager_25": {
       "inputs": {
-        "logos-nix": "logos-nix_533",
-        "logos-package": "logos-package_61",
+        "logos-nix": "logos-nix_534",
+        "logos-package": "logos-package_62",
         "nix-bundle-appimage": "nix-bundle-appimage_25",
         "nix-bundle-dir": "nix-bundle-dir_86",
         "nixpkgs": [
@@ -28636,8 +28654,8 @@
     },
     "logos-package-manager_26": {
       "inputs": {
-        "logos-nix": "logos-nix_550",
-        "logos-package": "logos-package_64",
+        "logos-nix": "logos-nix_551",
+        "logos-package": "logos-package_65",
         "nix-bundle-appimage": "nix-bundle-appimage_26",
         "nix-bundle-dir": "nix-bundle-dir_90",
         "nixpkgs": [
@@ -28669,8 +28687,8 @@
     },
     "logos-package-manager_27": {
       "inputs": {
-        "logos-nix": "logos-nix_564",
-        "logos-package": "logos-package_66",
+        "logos-nix": "logos-nix_565",
+        "logos-package": "logos-package_67",
         "nix-bundle-appimage": "nix-bundle-appimage_27",
         "nix-bundle-dir": "nix-bundle-dir_93",
         "nixpkgs": [
@@ -28699,8 +28717,8 @@
     },
     "logos-package-manager_28": {
       "inputs": {
-        "logos-nix": "logos-nix_583",
-        "logos-package": "logos-package_69",
+        "logos-nix": "logos-nix_584",
+        "logos-package": "logos-package_70",
         "nix-bundle-appimage": "nix-bundle-appimage_28",
         "nix-bundle-dir": "nix-bundle-dir_97",
         "nixpkgs": [
@@ -28728,8 +28746,8 @@
     },
     "logos-package-manager_29": {
       "inputs": {
-        "logos-nix": "logos-nix_631",
-        "logos-package": "logos-package_72",
+        "logos-nix": "logos-nix_632",
+        "logos-package": "logos-package_73",
         "nix-bundle-appimage": "nix-bundle-appimage_30",
         "nix-bundle-dir": "nix-bundle-dir_102",
         "nixpkgs": [
@@ -28800,8 +28818,8 @@
     },
     "logos-package-manager_30": {
       "inputs": {
-        "logos-nix": "logos-nix_648",
-        "logos-package": "logos-package_75",
+        "logos-nix": "logos-nix_649",
+        "logos-package": "logos-package_76",
         "nix-bundle-appimage": "nix-bundle-appimage_31",
         "nix-bundle-dir": "nix-bundle-dir_106",
         "nixpkgs": [
@@ -28835,8 +28853,8 @@
     },
     "logos-package-manager_31": {
       "inputs": {
-        "logos-nix": "logos-nix_675",
-        "logos-package": "logos-package_77",
+        "logos-nix": "logos-nix_676",
+        "logos-package": "logos-package_78",
         "nix-bundle-appimage": "nix-bundle-appimage_32",
         "nix-bundle-dir": "nix-bundle-dir_109",
         "nixpkgs": [
@@ -28872,8 +28890,8 @@
     },
     "logos-package-manager_32": {
       "inputs": {
-        "logos-nix": "logos-nix_692",
-        "logos-package": "logos-package_80",
+        "logos-nix": "logos-nix_693",
+        "logos-package": "logos-package_81",
         "nix-bundle-appimage": "nix-bundle-appimage_33",
         "nix-bundle-dir": "nix-bundle-dir_113",
         "nixpkgs": [
@@ -28908,8 +28926,8 @@
     },
     "logos-package-manager_33": {
       "inputs": {
-        "logos-nix": "logos-nix_703",
-        "logos-package": "logos-package_82",
+        "logos-nix": "logos-nix_704",
+        "logos-package": "logos-package_83",
         "nix-bundle-appimage": "nix-bundle-appimage_34",
         "nix-bundle-dir": "nix-bundle-dir_116",
         "nixpkgs": [
@@ -28941,8 +28959,8 @@
     },
     "logos-package-manager_34": {
       "inputs": {
-        "logos-nix": "logos-nix_720",
-        "logos-package": "logos-package_85",
+        "logos-nix": "logos-nix_721",
+        "logos-package": "logos-package_86",
         "nix-bundle-appimage": "nix-bundle-appimage_35",
         "nix-bundle-dir": "nix-bundle-dir_120",
         "nixpkgs": [
@@ -28973,8 +28991,8 @@
     },
     "logos-package-manager_35": {
       "inputs": {
-        "logos-nix": "logos-nix_761",
-        "logos-package": "logos-package_87",
+        "logos-nix": "logos-nix_762",
+        "logos-package": "logos-package_88",
         "nix-bundle-appimage": "nix-bundle-appimage_36",
         "nix-bundle-dir": "nix-bundle-dir_123",
         "nixpkgs": [
@@ -29010,8 +29028,8 @@
     },
     "logos-package-manager_36": {
       "inputs": {
-        "logos-nix": "logos-nix_778",
-        "logos-package": "logos-package_90",
+        "logos-nix": "logos-nix_779",
+        "logos-package": "logos-package_91",
         "nix-bundle-appimage": "nix-bundle-appimage_37",
         "nix-bundle-dir": "nix-bundle-dir_127",
         "nixpkgs": [
@@ -29046,8 +29064,8 @@
     },
     "logos-package-manager_37": {
       "inputs": {
-        "logos-nix": "logos-nix_805",
-        "logos-package": "logos-package_92",
+        "logos-nix": "logos-nix_806",
+        "logos-package": "logos-package_93",
         "nix-bundle-appimage": "nix-bundle-appimage_38",
         "nix-bundle-dir": "nix-bundle-dir_130",
         "nixpkgs": [
@@ -29084,8 +29102,8 @@
     },
     "logos-package-manager_38": {
       "inputs": {
-        "logos-nix": "logos-nix_822",
-        "logos-package": "logos-package_95",
+        "logos-nix": "logos-nix_823",
+        "logos-package": "logos-package_96",
         "nix-bundle-appimage": "nix-bundle-appimage_39",
         "nix-bundle-dir": "nix-bundle-dir_134",
         "nixpkgs": [
@@ -29121,8 +29139,8 @@
     },
     "logos-package-manager_39": {
       "inputs": {
-        "logos-nix": "logos-nix_833",
-        "logos-package": "logos-package_97",
+        "logos-nix": "logos-nix_834",
+        "logos-package": "logos-package_98",
         "nix-bundle-appimage": "nix-bundle-appimage_40",
         "nix-bundle-dir": "nix-bundle-dir_137",
         "nixpkgs": [
@@ -29190,8 +29208,8 @@
     },
     "logos-package-manager_40": {
       "inputs": {
-        "logos-nix": "logos-nix_850",
-        "logos-package": "logos-package_100",
+        "logos-nix": "logos-nix_851",
+        "logos-package": "logos-package_101",
         "nix-bundle-appimage": "nix-bundle-appimage_41",
         "nix-bundle-dir": "nix-bundle-dir_141",
         "nixpkgs": [
@@ -29223,8 +29241,8 @@
     },
     "logos-package-manager_41": {
       "inputs": {
-        "logos-nix": "logos-nix_864",
-        "logos-package": "logos-package_102",
+        "logos-nix": "logos-nix_865",
+        "logos-package": "logos-package_103",
         "nix-bundle-appimage": "nix-bundle-appimage_42",
         "nix-bundle-dir": "nix-bundle-dir_144",
         "nixpkgs": [
@@ -29253,8 +29271,8 @@
     },
     "logos-package-manager_42": {
       "inputs": {
-        "logos-nix": "logos-nix_883",
-        "logos-package": "logos-package_105",
+        "logos-nix": "logos-nix_884",
+        "logos-package": "logos-package_106",
         "nix-bundle-appimage": "nix-bundle-appimage_43",
         "nix-bundle-dir": "nix-bundle-dir_148",
         "nixpkgs": [
@@ -29282,8 +29300,8 @@
     },
     "logos-package-manager_43": {
       "inputs": {
-        "logos-nix": "logos-nix_891",
-        "logos-package": "logos-package_107",
+        "logos-nix": "logos-nix_892",
+        "logos-package": "logos-package_108",
         "nix-bundle-appimage": "nix-bundle-appimage_44",
         "nix-bundle-dir": "nix-bundle-dir_151",
         "nixpkgs": [
@@ -29513,7 +29531,37 @@
     },
     "logos-package_100": {
       "inputs": {
-        "logos-nix": "logos-nix_851",
+        "logos-nix": "logos-nix_848",
+        "nixpkgs": [
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_101": {
+      "inputs": {
+        "logos-nix": "logos-nix_852",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -29542,9 +29590,9 @@
         "type": "github"
       }
     },
-    "logos-package_101": {
+    "logos-package_102": {
       "inputs": {
-        "logos-nix": "logos-nix_856",
+        "logos-nix": "logos-nix_857",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -29573,9 +29621,9 @@
         "type": "github"
       }
     },
-    "logos-package_102": {
+    "logos-package_103": {
       "inputs": {
-        "logos-nix": "logos-nix_865",
+        "logos-nix": "logos-nix_866",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -29601,9 +29649,9 @@
         "type": "github"
       }
     },
-    "logos-package_103": {
+    "logos-package_104": {
       "inputs": {
-        "logos-nix": "logos-nix_876",
+        "logos-nix": "logos-nix_877",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -29628,9 +29676,9 @@
         "type": "github"
       }
     },
-    "logos-package_104": {
+    "logos-package_105": {
       "inputs": {
-        "logos-nix": "logos-nix_880",
+        "logos-nix": "logos-nix_881",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -29654,9 +29702,9 @@
         "type": "github"
       }
     },
-    "logos-package_105": {
+    "logos-package_106": {
       "inputs": {
-        "logos-nix": "logos-nix_884",
+        "logos-nix": "logos-nix_885",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -29681,9 +29729,9 @@
         "type": "github"
       }
     },
-    "logos-package_106": {
+    "logos-package_107": {
       "inputs": {
-        "logos-nix": "logos-nix_889",
+        "logos-nix": "logos-nix_890",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -29708,9 +29756,9 @@
         "type": "github"
       }
     },
-    "logos-package_107": {
+    "logos-package_108": {
       "inputs": {
-        "logos-nix": "logos-nix_892",
+        "logos-nix": "logos-nix_893",
         "nixpkgs": [
           "package_manager",
           "logos-package-manager",
@@ -30558,7 +30606,30 @@
     },
     "logos-package_36": {
       "inputs": {
-        "logos-nix": "logos-nix_332",
+        "logos-nix": "logos-nix_296",
+        "nixpkgs": [
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784062467,
+        "narHash": "sha256-WhmfrFrvcsj3I3sSuoNWb2hkJn/Ir/fRcNav5WQpd2E=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "9642c98304233f6c8344220c93b3e13768be8a38",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_37": {
+      "inputs": {
+        "logos-nix": "logos-nix_333",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -30590,42 +30661,9 @@
         "type": "github"
       }
     },
-    "logos-package_37": {
-      "inputs": {
-        "logos-nix": "logos-nix_341",
-        "nixpkgs": [
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
     "logos-package_38": {
       "inputs": {
-        "logos-nix": "logos-nix_345",
+        "logos-nix": "logos-nix_342",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -30635,6 +30673,7 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -30657,7 +30696,7 @@
     },
     "logos-package_39": {
       "inputs": {
-        "logos-nix": "logos-nix_349",
+        "logos-nix": "logos-nix_346",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -30667,19 +30706,18 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
         "type": "github"
       },
       "original": {
@@ -30722,7 +30760,40 @@
     },
     "logos-package_40": {
       "inputs": {
-        "logos-nix": "logos-nix_354",
+        "logos-nix": "logos-nix_350",
+        "nixpkgs": [
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_41": {
+      "inputs": {
+        "logos-nix": "logos-nix_355",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -30753,9 +30824,9 @@
         "type": "github"
       }
     },
-    "logos-package_41": {
+    "logos-package_42": {
       "inputs": {
-        "logos-nix": "logos-nix_376",
+        "logos-nix": "logos-nix_377",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -30788,43 +30859,9 @@
         "type": "github"
       }
     },
-    "logos-package_42": {
-      "inputs": {
-        "logos-nix": "logos-nix_385",
-        "nixpkgs": [
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
     "logos-package_43": {
       "inputs": {
-        "logos-nix": "logos-nix_389",
+        "logos-nix": "logos-nix_386",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -30835,6 +30872,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -30857,7 +30895,40 @@
     },
     "logos-package_44": {
       "inputs": {
-        "logos-nix": "logos-nix_393",
+        "logos-nix": "logos-nix_390",
+        "nixpkgs": [
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_45": {
+      "inputs": {
+        "logos-nix": "logos-nix_394",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -30889,9 +30960,9 @@
         "type": "github"
       }
     },
-    "logos-package_45": {
+    "logos-package_46": {
       "inputs": {
-        "logos-nix": "logos-nix_398",
+        "logos-nix": "logos-nix_399",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -30923,9 +30994,9 @@
         "type": "github"
       }
     },
-    "logos-package_46": {
+    "logos-package_47": {
       "inputs": {
-        "logos-nix": "logos-nix_404",
+        "logos-nix": "logos-nix_405",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -30954,9 +31025,9 @@
         "type": "github"
       }
     },
-    "logos-package_47": {
+    "logos-package_48": {
       "inputs": {
-        "logos-nix": "logos-nix_413",
+        "logos-nix": "logos-nix_414",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -30984,9 +31055,9 @@
         "type": "github"
       }
     },
-    "logos-package_48": {
+    "logos-package_49": {
       "inputs": {
-        "logos-nix": "logos-nix_417",
+        "logos-nix": "logos-nix_418",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -31005,36 +31076,6 @@
         "owner": "logos-co",
         "repo": "logos-package",
         "rev": "ab885df3641e9adb61ff16e42d3e6f63b24db8f6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_49": {
-      "inputs": {
-        "logos-nix": "logos-nix_421",
-        "nixpkgs": [
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
         "type": "github"
       },
       "original": {
@@ -31077,7 +31118,37 @@
     },
     "logos-package_50": {
       "inputs": {
-        "logos-nix": "logos-nix_426",
+        "logos-nix": "logos-nix_422",
+        "nixpkgs": [
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_51": {
+      "inputs": {
+        "logos-nix": "logos-nix_427",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -31105,9 +31176,9 @@
         "type": "github"
       }
     },
-    "logos-package_51": {
+    "logos-package_52": {
       "inputs": {
-        "logos-nix": "logos-nix_462",
+        "logos-nix": "logos-nix_463",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -31140,43 +31211,9 @@
         "type": "github"
       }
     },
-    "logos-package_52": {
-      "inputs": {
-        "logos-nix": "logos-nix_471",
-        "nixpkgs": [
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
     "logos-package_53": {
       "inputs": {
-        "logos-nix": "logos-nix_475",
+        "logos-nix": "logos-nix_472",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -31187,6 +31224,7 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -31209,7 +31247,40 @@
     },
     "logos-package_54": {
       "inputs": {
-        "logos-nix": "logos-nix_479",
+        "logos-nix": "logos-nix_476",
+        "nixpkgs": [
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_55": {
+      "inputs": {
+        "logos-nix": "logos-nix_480",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -31222,40 +31293,6 @@
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_55": {
-      "inputs": {
-        "logos-nix": "logos-nix_484",
-        "nixpkgs": [
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -31277,7 +31314,41 @@
     },
     "logos-package_56": {
       "inputs": {
-        "logos-nix": "logos-nix_506",
+        "logos-nix": "logos-nix_485",
+        "nixpkgs": [
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_57": {
+      "inputs": {
+        "logos-nix": "logos-nix_507",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -31311,44 +31382,9 @@
         "type": "github"
       }
     },
-    "logos-package_57": {
-      "inputs": {
-        "logos-nix": "logos-nix_515",
-        "nixpkgs": [
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
     "logos-package_58": {
       "inputs": {
-        "logos-nix": "logos-nix_519",
+        "logos-nix": "logos-nix_516",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -31360,6 +31396,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -31382,7 +31419,7 @@
     },
     "logos-package_59": {
       "inputs": {
-        "logos-nix": "logos-nix_523",
+        "logos-nix": "logos-nix_520",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -31394,19 +31431,18 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
         "type": "github"
       },
       "original": {
@@ -31451,7 +31487,42 @@
     },
     "logos-package_60": {
       "inputs": {
-        "logos-nix": "logos-nix_528",
+        "logos-nix": "logos-nix_524",
+        "nixpkgs": [
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_61": {
+      "inputs": {
+        "logos-nix": "logos-nix_529",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -31484,9 +31555,9 @@
         "type": "github"
       }
     },
-    "logos-package_61": {
+    "logos-package_62": {
       "inputs": {
-        "logos-nix": "logos-nix_534",
+        "logos-nix": "logos-nix_535",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -31516,40 +31587,9 @@
         "type": "github"
       }
     },
-    "logos-package_62": {
-      "inputs": {
-        "logos-nix": "logos-nix_543",
-        "nixpkgs": [
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
     "logos-package_63": {
       "inputs": {
-        "logos-nix": "logos-nix_547",
+        "logos-nix": "logos-nix_544",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -31557,6 +31597,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -31579,7 +31620,37 @@
     },
     "logos-package_64": {
       "inputs": {
-        "logos-nix": "logos-nix_551",
+        "logos-nix": "logos-nix_548",
+        "nixpkgs": [
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_65": {
+      "inputs": {
+        "logos-nix": "logos-nix_552",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -31608,9 +31679,9 @@
         "type": "github"
       }
     },
-    "logos-package_65": {
+    "logos-package_66": {
       "inputs": {
-        "logos-nix": "logos-nix_556",
+        "logos-nix": "logos-nix_557",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -31639,9 +31710,9 @@
         "type": "github"
       }
     },
-    "logos-package_66": {
+    "logos-package_67": {
       "inputs": {
-        "logos-nix": "logos-nix_565",
+        "logos-nix": "logos-nix_566",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -31667,9 +31738,9 @@
         "type": "github"
       }
     },
-    "logos-package_67": {
+    "logos-package_68": {
       "inputs": {
-        "logos-nix": "logos-nix_576",
+        "logos-nix": "logos-nix_577",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -31694,9 +31765,9 @@
         "type": "github"
       }
     },
-    "logos-package_68": {
+    "logos-package_69": {
       "inputs": {
-        "logos-nix": "logos-nix_580",
+        "logos-nix": "logos-nix_581",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -31712,33 +31783,6 @@
         "owner": "logos-co",
         "repo": "logos-package",
         "rev": "ab885df3641e9adb61ff16e42d3e6f63b24db8f6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_69": {
-      "inputs": {
-        "logos-nix": "logos-nix_584",
-        "nixpkgs": [
-          "package_downloader",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1781873979,
-        "narHash": "sha256-Z5XUSB9wfdrmQhG/0fehJeBd9CjrlIEeO+mKDhE46H4=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "c207525d30f48620696668c38486884bad5384bc",
         "type": "github"
       },
       "original": {
@@ -31782,7 +31826,34 @@
     },
     "logos-package_70": {
       "inputs": {
-        "logos-nix": "logos-nix_589",
+        "logos-nix": "logos-nix_585",
+        "nixpkgs": [
+          "package_downloader",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781873979,
+        "narHash": "sha256-Z5XUSB9wfdrmQhG/0fehJeBd9CjrlIEeO+mKDhE46H4=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "c207525d30f48620696668c38486884bad5384bc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_71": {
+      "inputs": {
+        "logos-nix": "logos-nix_590",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -31807,9 +31878,9 @@
         "type": "github"
       }
     },
-    "logos-package_71": {
+    "logos-package_72": {
       "inputs": {
-        "logos-nix": "logos-nix_592",
+        "logos-nix": "logos-nix_593",
         "nixpkgs": [
           "package_downloader",
           "logos-package-downloader",
@@ -31832,9 +31903,9 @@
         "type": "github"
       }
     },
-    "logos-package_72": {
+    "logos-package_73": {
       "inputs": {
-        "logos-nix": "logos-nix_632",
+        "logos-nix": "logos-nix_633",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -31866,42 +31937,9 @@
         "type": "github"
       }
     },
-    "logos-package_73": {
-      "inputs": {
-        "logos-nix": "logos-nix_641",
-        "nixpkgs": [
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
     "logos-package_74": {
       "inputs": {
-        "logos-nix": "logos-nix_645",
+        "logos-nix": "logos-nix_642",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -31911,6 +31949,7 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -31933,7 +31972,39 @@
     },
     "logos-package_75": {
       "inputs": {
-        "logos-nix": "logos-nix_649",
+        "logos-nix": "logos-nix_646",
+        "nixpkgs": [
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_76": {
+      "inputs": {
+        "logos-nix": "logos-nix_650",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -31945,39 +32016,6 @@
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_76": {
-      "inputs": {
-        "logos-nix": "logos-nix_654",
-        "nixpkgs": [
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -31999,7 +32037,40 @@
     },
     "logos-package_77": {
       "inputs": {
-        "logos-nix": "logos-nix_676",
+        "logos-nix": "logos-nix_655",
+        "nixpkgs": [
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_78": {
+      "inputs": {
+        "logos-nix": "logos-nix_677",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -32032,43 +32103,9 @@
         "type": "github"
       }
     },
-    "logos-package_78": {
-      "inputs": {
-        "logos-nix": "logos-nix_685",
-        "nixpkgs": [
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
     "logos-package_79": {
       "inputs": {
-        "logos-nix": "logos-nix_689",
+        "logos-nix": "logos-nix_686",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -32079,6 +32116,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -32133,7 +32171,40 @@
     },
     "logos-package_80": {
       "inputs": {
-        "logos-nix": "logos-nix_693",
+        "logos-nix": "logos-nix_690",
+        "nixpkgs": [
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_81": {
+      "inputs": {
+        "logos-nix": "logos-nix_694",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -32165,9 +32236,9 @@
         "type": "github"
       }
     },
-    "logos-package_81": {
+    "logos-package_82": {
       "inputs": {
-        "logos-nix": "logos-nix_698",
+        "logos-nix": "logos-nix_699",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -32199,9 +32270,9 @@
         "type": "github"
       }
     },
-    "logos-package_82": {
+    "logos-package_83": {
       "inputs": {
-        "logos-nix": "logos-nix_704",
+        "logos-nix": "logos-nix_705",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -32230,9 +32301,9 @@
         "type": "github"
       }
     },
-    "logos-package_83": {
+    "logos-package_84": {
       "inputs": {
-        "logos-nix": "logos-nix_713",
+        "logos-nix": "logos-nix_714",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -32260,9 +32331,9 @@
         "type": "github"
       }
     },
-    "logos-package_84": {
+    "logos-package_85": {
       "inputs": {
-        "logos-nix": "logos-nix_717",
+        "logos-nix": "logos-nix_718",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -32289,9 +32360,9 @@
         "type": "github"
       }
     },
-    "logos-package_85": {
+    "logos-package_86": {
       "inputs": {
-        "logos-nix": "logos-nix_721",
+        "logos-nix": "logos-nix_722",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -32300,36 +32371,6 @@
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_86": {
-      "inputs": {
-        "logos-nix": "logos-nix_726",
-        "nixpkgs": [
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -32351,7 +32392,37 @@
     },
     "logos-package_87": {
       "inputs": {
-        "logos-nix": "logos-nix_762",
+        "logos-nix": "logos-nix_727",
+        "nixpkgs": [
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_88": {
+      "inputs": {
+        "logos-nix": "logos-nix_763",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -32384,43 +32455,9 @@
         "type": "github"
       }
     },
-    "logos-package_88": {
-      "inputs": {
-        "logos-nix": "logos-nix_771",
-        "nixpkgs": [
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
     "logos-package_89": {
       "inputs": {
-        "logos-nix": "logos-nix_775",
+        "logos-nix": "logos-nix_772",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -32431,6 +32468,7 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -32486,7 +32524,40 @@
     },
     "logos-package_90": {
       "inputs": {
-        "logos-nix": "logos-nix_779",
+        "logos-nix": "logos-nix_776",
+        "nixpkgs": [
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_91": {
+      "inputs": {
+        "logos-nix": "logos-nix_780",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -32499,40 +32570,6 @@
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_91": {
-      "inputs": {
-        "logos-nix": "logos-nix_784",
-        "nixpkgs": [
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -32554,7 +32591,41 @@
     },
     "logos-package_92": {
       "inputs": {
-        "logos-nix": "logos-nix_806",
+        "logos-nix": "logos-nix_785",
+        "nixpkgs": [
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_93": {
+      "inputs": {
+        "logos-nix": "logos-nix_807",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -32588,44 +32659,9 @@
         "type": "github"
       }
     },
-    "logos-package_93": {
-      "inputs": {
-        "logos-nix": "logos-nix_815",
-        "nixpkgs": [
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
     "logos-package_94": {
       "inputs": {
-        "logos-nix": "logos-nix_819",
+        "logos-nix": "logos-nix_816",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -32637,6 +32673,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -32659,7 +32696,41 @@
     },
     "logos-package_95": {
       "inputs": {
-        "logos-nix": "logos-nix_823",
+        "logos-nix": "logos-nix_820",
+        "nixpkgs": [
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_96": {
+      "inputs": {
+        "logos-nix": "logos-nix_824",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -32673,41 +32744,6 @@
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_96": {
-      "inputs": {
-        "logos-nix": "logos-nix_828",
-        "nixpkgs": [
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -32729,7 +32765,42 @@
     },
     "logos-package_97": {
       "inputs": {
-        "logos-nix": "logos-nix_834",
+        "logos-nix": "logos-nix_829",
+        "nixpkgs": [
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_98": {
+      "inputs": {
+        "logos-nix": "logos-nix_835",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -32759,40 +32830,9 @@
         "type": "github"
       }
     },
-    "logos-package_98": {
-      "inputs": {
-        "logos-nix": "logos-nix_843",
-        "nixpkgs": [
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
     "logos-package_99": {
       "inputs": {
-        "logos-nix": "logos-nix_847",
+        "logos-nix": "logos-nix_844",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -32800,6 +32840,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -32848,7 +32889,7 @@
     "logos-plugin-core_10": {
       "inputs": {
         "logos-module": "logos-module_45",
-        "logos-nix": "logos-nix_318",
+        "logos-nix": "logos-nix_319",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -32880,7 +32921,7 @@
     "logos-plugin-core_11": {
       "inputs": {
         "logos-module": "logos-module_51",
-        "logos-nix": "logos-nix_362",
+        "logos-nix": "logos-nix_363",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -32913,7 +32954,7 @@
     "logos-plugin-core_12": {
       "inputs": {
         "logos-module": "logos-module_59",
-        "logos-nix": "logos-nix_441",
+        "logos-nix": "logos-nix_442",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -32943,7 +32984,7 @@
     "logos-plugin-core_13": {
       "inputs": {
         "logos-module": "logos-module_62",
-        "logos-nix": "logos-nix_448",
+        "logos-nix": "logos-nix_449",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -32976,7 +33017,7 @@
     "logos-plugin-core_14": {
       "inputs": {
         "logos-module": "logos-module_68",
-        "logos-nix": "logos-nix_492",
+        "logos-nix": "logos-nix_493",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -33010,7 +33051,7 @@
     "logos-plugin-core_15": {
       "inputs": {
         "logos-module": "logos-module_76",
-        "logos-nix": "logos-nix_600",
+        "logos-nix": "logos-nix_601",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -33036,7 +33077,7 @@
     "logos-plugin-core_16": {
       "inputs": {
         "logos-module": "logos-module_79",
-        "logos-nix": "logos-nix_609",
+        "logos-nix": "logos-nix_610",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -33065,7 +33106,7 @@
     "logos-plugin-core_17": {
       "inputs": {
         "logos-module": "logos-module_82",
-        "logos-nix": "logos-nix_618",
+        "logos-nix": "logos-nix_619",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -33097,7 +33138,7 @@
     "logos-plugin-core_18": {
       "inputs": {
         "logos-module": "logos-module_88",
-        "logos-nix": "logos-nix_662",
+        "logos-nix": "logos-nix_663",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -33130,7 +33171,7 @@
     "logos-plugin-core_19": {
       "inputs": {
         "logos-module": "logos-module_96",
-        "logos-nix": "logos-nix_741",
+        "logos-nix": "logos-nix_742",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -33188,7 +33229,7 @@
     "logos-plugin-core_20": {
       "inputs": {
         "logos-module": "logos-module_99",
-        "logos-nix": "logos-nix_748",
+        "logos-nix": "logos-nix_749",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -33221,7 +33262,7 @@
     "logos-plugin-core_21": {
       "inputs": {
         "logos-module": "logos-module_105",
-        "logos-nix": "logos-nix_792",
+        "logos-nix": "logos-nix_793",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -33412,7 +33453,7 @@
     "logos-plugin-core_8": {
       "inputs": {
         "logos-module": "logos-module_39",
-        "logos-nix": "logos-nix_300",
+        "logos-nix": "logos-nix_301",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -33438,7 +33479,7 @@
     "logos-plugin-core_9": {
       "inputs": {
         "logos-module": "logos-module_42",
-        "logos-nix": "logos-nix_309",
+        "logos-nix": "logos-nix_310",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -33492,7 +33533,7 @@
     "logos-plugin-qt_10": {
       "inputs": {
         "logos-module": "logos-module_46",
-        "logos-nix": "logos-nix_320",
+        "logos-nix": "logos-nix_321",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -33524,7 +33565,7 @@
     "logos-plugin-qt_11": {
       "inputs": {
         "logos-module": "logos-module_52",
-        "logos-nix": "logos-nix_364",
+        "logos-nix": "logos-nix_365",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -33557,7 +33598,7 @@
     "logos-plugin-qt_12": {
       "inputs": {
         "logos-module": "logos-module_60",
-        "logos-nix": "logos-nix_443",
+        "logos-nix": "logos-nix_444",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -33587,7 +33628,7 @@
     "logos-plugin-qt_13": {
       "inputs": {
         "logos-module": "logos-module_63",
-        "logos-nix": "logos-nix_450",
+        "logos-nix": "logos-nix_451",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -33620,7 +33661,7 @@
     "logos-plugin-qt_14": {
       "inputs": {
         "logos-module": "logos-module_69",
-        "logos-nix": "logos-nix_494",
+        "logos-nix": "logos-nix_495",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -33654,7 +33695,7 @@
     "logos-plugin-qt_15": {
       "inputs": {
         "logos-module": "logos-module_77",
-        "logos-nix": "logos-nix_602",
+        "logos-nix": "logos-nix_603",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -33680,7 +33721,7 @@
     "logos-plugin-qt_16": {
       "inputs": {
         "logos-module": "logos-module_80",
-        "logos-nix": "logos-nix_611",
+        "logos-nix": "logos-nix_612",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -33709,7 +33750,7 @@
     "logos-plugin-qt_17": {
       "inputs": {
         "logos-module": "logos-module_83",
-        "logos-nix": "logos-nix_620",
+        "logos-nix": "logos-nix_621",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -33741,7 +33782,7 @@
     "logos-plugin-qt_18": {
       "inputs": {
         "logos-module": "logos-module_89",
-        "logos-nix": "logos-nix_664",
+        "logos-nix": "logos-nix_665",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -33774,7 +33815,7 @@
     "logos-plugin-qt_19": {
       "inputs": {
         "logos-module": "logos-module_97",
-        "logos-nix": "logos-nix_743",
+        "logos-nix": "logos-nix_744",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -33832,7 +33873,7 @@
     "logos-plugin-qt_20": {
       "inputs": {
         "logos-module": "logos-module_100",
-        "logos-nix": "logos-nix_750",
+        "logos-nix": "logos-nix_751",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -33865,7 +33906,7 @@
     "logos-plugin-qt_21": {
       "inputs": {
         "logos-module": "logos-module_106",
-        "logos-nix": "logos-nix_794",
+        "logos-nix": "logos-nix_795",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -34056,7 +34097,7 @@
     "logos-plugin-qt_8": {
       "inputs": {
         "logos-module": "logos-module_40",
-        "logos-nix": "logos-nix_302",
+        "logos-nix": "logos-nix_303",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -34082,7 +34123,7 @@
     "logos-plugin-qt_9": {
       "inputs": {
         "logos-module": "logos-module_43",
-        "logos-nix": "logos-nix_311",
+        "logos-nix": "logos-nix_312",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -34134,7 +34175,7 @@
     },
     "logos-protocol_10": {
       "inputs": {
-        "logos-nix": "logos-nix_303",
+        "logos-nix": "logos-nix_304",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -34159,7 +34200,7 @@
     },
     "logos-protocol_11": {
       "inputs": {
-        "logos-nix": "logos-nix_312",
+        "logos-nix": "logos-nix_313",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -34255,7 +34296,7 @@
     },
     "logos-protocol_14": {
       "inputs": {
-        "logos-nix": "logos-nix_569",
+        "logos-nix": "logos-nix_570",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -34406,7 +34447,7 @@
     },
     "logos-protocol_19": {
       "inputs": {
-        "logos-nix": "logos-nix_603",
+        "logos-nix": "logos-nix_604",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -34458,7 +34499,7 @@
     },
     "logos-protocol_20": {
       "inputs": {
-        "logos-nix": "logos-nix_612",
+        "logos-nix": "logos-nix_613",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -34554,7 +34595,7 @@
     },
     "logos-protocol_23": {
       "inputs": {
-        "logos-nix": "logos-nix_869",
+        "logos-nix": "logos-nix_870",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -34941,7 +34982,7 @@
     },
     "logos-qt-mcp_10": {
       "inputs": {
-        "logos-nix": "logos-nix_410",
+        "logos-nix": "logos-nix_411",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -34970,7 +35011,7 @@
     },
     "logos-qt-mcp_11": {
       "inputs": {
-        "logos-nix": "logos-nix_468",
+        "logos-nix": "logos-nix_469",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -35002,7 +35043,7 @@
     },
     "logos-qt-mcp_12": {
       "inputs": {
-        "logos-nix": "logos-nix_512",
+        "logos-nix": "logos-nix_513",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -35035,7 +35076,7 @@
     },
     "logos-qt-mcp_13": {
       "inputs": {
-        "logos-nix": "logos-nix_540",
+        "logos-nix": "logos-nix_541",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -35065,7 +35106,7 @@
     },
     "logos-qt-mcp_14": {
       "inputs": {
-        "logos-nix": "logos-nix_573",
+        "logos-nix": "logos-nix_574",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -35091,7 +35132,7 @@
     },
     "logos-qt-mcp_15": {
       "inputs": {
-        "logos-nix": "logos-nix_638",
+        "logos-nix": "logos-nix_639",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -35122,7 +35163,7 @@
     },
     "logos-qt-mcp_16": {
       "inputs": {
-        "logos-nix": "logos-nix_682",
+        "logos-nix": "logos-nix_683",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -35154,7 +35195,7 @@
     },
     "logos-qt-mcp_17": {
       "inputs": {
-        "logos-nix": "logos-nix_710",
+        "logos-nix": "logos-nix_711",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -35183,7 +35224,7 @@
     },
     "logos-qt-mcp_18": {
       "inputs": {
-        "logos-nix": "logos-nix_768",
+        "logos-nix": "logos-nix_769",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -35215,7 +35256,7 @@
     },
     "logos-qt-mcp_19": {
       "inputs": {
-        "logos-nix": "logos-nix_812",
+        "logos-nix": "logos-nix_813",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -35279,7 +35320,7 @@
     },
     "logos-qt-mcp_20": {
       "inputs": {
-        "logos-nix": "logos-nix_840",
+        "logos-nix": "logos-nix_841",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -35309,7 +35350,7 @@
     },
     "logos-qt-mcp_21": {
       "inputs": {
-        "logos-nix": "logos-nix_873",
+        "logos-nix": "logos-nix_874",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -35480,7 +35521,7 @@
     },
     "logos-qt-mcp_8": {
       "inputs": {
-        "logos-nix": "logos-nix_338",
+        "logos-nix": "logos-nix_339",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -35511,7 +35552,7 @@
     },
     "logos-qt-mcp_9": {
       "inputs": {
-        "logos-nix": "logos-nix_382",
+        "logos-nix": "logos-nix_383",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -35637,7 +35678,7 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_22",
-        "logos-nix": "logos-nix_570",
+        "logos-nix": "logos-nix_571",
         "logos-protocol": [
           "package_downloader",
           "logos-module-builder",
@@ -35807,7 +35848,7 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_28",
-        "logos-nix": "logos-nix_604",
+        "logos-nix": "logos-nix_605",
         "logos-protocol": [
           "package_manager",
           "logos-module-builder",
@@ -35846,7 +35887,7 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_31",
-        "logos-nix": "logos-nix_613",
+        "logos-nix": "logos-nix_614",
         "logos-protocol": [
           "package_manager",
           "logos-module-builder",
@@ -35943,7 +35984,7 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_35",
-        "logos-nix": "logos-nix_870",
+        "logos-nix": "logos-nix_871",
         "logos-protocol": [
           "package_manager",
           "logos-module-builder",
@@ -36361,7 +36402,7 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_15",
-        "logos-nix": "logos-nix_304",
+        "logos-nix": "logos-nix_305",
         "logos-protocol": [
           "package_downloader",
           "logos-module-builder",
@@ -36400,7 +36441,7 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_18",
-        "logos-nix": "logos-nix_313",
+        "logos-nix": "logos-nix_314",
         "logos-protocol": [
           "package_downloader",
           "logos-module-builder",
@@ -36784,7 +36825,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_32",
         "logos-design-system": "logos-design-system_8",
         "logos-liblogos": "logos-liblogos_8",
-        "logos-nix": "logos-nix_337",
+        "logos-nix": "logos-nix_338",
         "logos-qt-mcp": "logos-qt-mcp_8",
         "logos-view-module-runtime": "logos-view-module-runtime_8",
         "nix-bundle-lgx": "nix-bundle-lgx_22",
@@ -36822,7 +36863,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_37",
         "logos-design-system": "logos-design-system_10",
         "logos-liblogos": "logos-liblogos_10",
-        "logos-nix": "logos-nix_381",
+        "logos-nix": "logos-nix_382",
         "logos-qt-mcp": "logos-qt-mcp_9",
         "logos-view-module-runtime": "logos-view-module-runtime_9",
         "nix-bundle-lgx": "nix-bundle-lgx_25",
@@ -36861,7 +36902,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_48",
         "logos-design-system": "logos-design-system_13",
         "logos-liblogos": "logos-liblogos_13",
-        "logos-nix": "logos-nix_539",
+        "logos-nix": "logos-nix_540",
         "logos-qt-mcp": "logos-qt-mcp_13",
         "logos-view-module-runtime": "logos-view-module-runtime_13",
         "nix-bundle-lgx": "nix-bundle-lgx_37",
@@ -36897,7 +36938,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_45",
         "logos-design-system": "logos-design-system_12",
         "logos-liblogos": "logos-liblogos_12",
-        "logos-nix": "logos-nix_467",
+        "logos-nix": "logos-nix_468",
         "logos-qt-mcp": "logos-qt-mcp_11",
         "logos-view-module-runtime": "logos-view-module-runtime_11",
         "nix-bundle-lgx": "nix-bundle-lgx_31",
@@ -36936,7 +36977,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_50",
         "logos-design-system": "logos-design-system_14",
         "logos-liblogos": "logos-liblogos_14",
-        "logos-nix": "logos-nix_511",
+        "logos-nix": "logos-nix_512",
         "logos-qt-mcp": "logos-qt-mcp_12",
         "logos-view-module-runtime": "logos-view-module-runtime_12",
         "nix-bundle-lgx": "nix-bundle-lgx_34",
@@ -36976,7 +37017,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_70",
         "logos-design-system": "logos-design-system_18",
         "logos-liblogos": "logos-liblogos_18",
-        "logos-nix": "logos-nix_872",
+        "logos-nix": "logos-nix_873",
         "logos-protocol": "logos-protocol_24",
         "logos-qt-mcp": "logos-qt-mcp_21",
         "logos-qt-sdk": "logos-qt-sdk_19",
@@ -37010,7 +37051,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_63",
         "logos-design-system": "logos-design-system_16",
         "logos-liblogos": "logos-liblogos_16",
-        "logos-nix": "logos-nix_709",
+        "logos-nix": "logos-nix_710",
         "logos-qt-mcp": "logos-qt-mcp_17",
         "logos-view-module-runtime": "logos-view-module-runtime_17",
         "nix-bundle-lgx": "nix-bundle-lgx_49",
@@ -37045,7 +37086,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_60",
         "logos-design-system": "logos-design-system_15",
         "logos-liblogos": "logos-liblogos_15",
-        "logos-nix": "logos-nix_637",
+        "logos-nix": "logos-nix_638",
         "logos-qt-mcp": "logos-qt-mcp_15",
         "logos-view-module-runtime": "logos-view-module-runtime_15",
         "nix-bundle-lgx": "nix-bundle-lgx_43",
@@ -37083,7 +37124,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_65",
         "logos-design-system": "logos-design-system_17",
         "logos-liblogos": "logos-liblogos_17",
-        "logos-nix": "logos-nix_681",
+        "logos-nix": "logos-nix_682",
         "logos-qt-mcp": "logos-qt-mcp_16",
         "logos-view-module-runtime": "logos-view-module-runtime_16",
         "nix-bundle-lgx": "nix-bundle-lgx_46",
@@ -37122,7 +37163,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_76",
         "logos-design-system": "logos-design-system_20",
         "logos-liblogos": "logos-liblogos_20",
-        "logos-nix": "logos-nix_839",
+        "logos-nix": "logos-nix_840",
         "logos-qt-mcp": "logos-qt-mcp_20",
         "logos-view-module-runtime": "logos-view-module-runtime_20",
         "nix-bundle-lgx": "nix-bundle-lgx_58",
@@ -37192,7 +37233,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_73",
         "logos-design-system": "logos-design-system_19",
         "logos-liblogos": "logos-liblogos_19",
-        "logos-nix": "logos-nix_767",
+        "logos-nix": "logos-nix_768",
         "logos-qt-mcp": "logos-qt-mcp_18",
         "logos-view-module-runtime": "logos-view-module-runtime_18",
         "nix-bundle-lgx": "nix-bundle-lgx_52",
@@ -37231,7 +37272,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_78",
         "logos-design-system": "logos-design-system_21",
         "logos-liblogos": "logos-liblogos_21",
-        "logos-nix": "logos-nix_811",
+        "logos-nix": "logos-nix_812",
         "logos-qt-mcp": "logos-qt-mcp_19",
         "logos-view-module-runtime": "logos-view-module-runtime_19",
         "nix-bundle-lgx": "nix-bundle-lgx_55",
@@ -37458,7 +37499,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_42",
         "logos-design-system": "logos-design-system_11",
         "logos-liblogos": "logos-liblogos_11",
-        "logos-nix": "logos-nix_572",
+        "logos-nix": "logos-nix_573",
         "logos-protocol": "logos-protocol_15",
         "logos-qt-mcp": "logos-qt-mcp_14",
         "logos-qt-sdk": "logos-qt-sdk_12",
@@ -37492,7 +37533,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_35",
         "logos-design-system": "logos-design-system_9",
         "logos-liblogos": "logos-liblogos_9",
-        "logos-nix": "logos-nix_409",
+        "logos-nix": "logos-nix_410",
         "logos-qt-mcp": "logos-qt-mcp_10",
         "logos-view-module-runtime": "logos-view-module-runtime_10",
         "nix-bundle-lgx": "nix-bundle-lgx_28",
@@ -37571,7 +37612,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_415",
+        "logos-nix": "logos-nix_416",
         "logos-protocol": "logos-protocol_12",
         "logos-qt-sdk": "logos-qt-sdk_10",
         "nixpkgs": [
@@ -37613,7 +37654,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_473",
+        "logos-nix": "logos-nix_474",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -37658,7 +37699,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_517",
+        "logos-nix": "logos-nix_518",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -37700,7 +37741,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_545",
+        "logos-nix": "logos-nix_546",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -37734,7 +37775,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_578",
+        "logos-nix": "logos-nix_579",
         "logos-protocol": "logos-protocol_18",
         "logos-qt-sdk": "logos-qt-sdk_14",
         "nixpkgs": [
@@ -37772,7 +37813,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_643",
+        "logos-nix": "logos-nix_644",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -37815,7 +37856,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_687",
+        "logos-nix": "logos-nix_688",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -37855,7 +37896,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_715",
+        "logos-nix": "logos-nix_716",
         "logos-protocol": "logos-protocol_21",
         "logos-qt-sdk": "logos-qt-sdk_17",
         "nixpkgs": [
@@ -37897,7 +37938,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_773",
+        "logos-nix": "logos-nix_774",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -37942,7 +37983,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_817",
+        "logos-nix": "logos-nix_818",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -38026,7 +38067,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_845",
+        "logos-nix": "logos-nix_846",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -38060,7 +38101,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_878",
+        "logos-nix": "logos-nix_879",
         "logos-protocol": "logos-protocol_27",
         "logos-qt-sdk": "logos-qt-sdk_21",
         "nixpkgs": [
@@ -38286,7 +38327,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_343",
+        "logos-nix": "logos-nix_344",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -38329,7 +38370,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_387",
+        "logos-nix": "logos-nix_388",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -38403,7 +38444,7 @@
     "logos-view-module-runtime_10": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_41",
-        "logos-nix": "logos-nix_411",
+        "logos-nix": "logos-nix_412",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -38445,7 +38486,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_469",
+        "logos-nix": "logos-nix_470",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -38491,7 +38532,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_513",
+        "logos-nix": "logos-nix_514",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -38525,7 +38566,7 @@
     "logos-view-module-runtime_13": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_54",
-        "logos-nix": "logos-nix_541",
+        "logos-nix": "logos-nix_542",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -38556,7 +38597,7 @@
     "logos-view-module-runtime_14": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_56",
-        "logos-nix": "logos-nix_574",
+        "logos-nix": "logos-nix_575",
         "logos-protocol": "logos-protocol_17",
         "logos-qt-sdk": "logos-qt-sdk_13",
         "nixpkgs": [
@@ -38596,7 +38637,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_639",
+        "logos-nix": "logos-nix_640",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -38640,7 +38681,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_683",
+        "logos-nix": "logos-nix_684",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -38673,7 +38714,7 @@
     "logos-view-module-runtime_17": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_69",
-        "logos-nix": "logos-nix_711",
+        "logos-nix": "logos-nix_712",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -38715,7 +38756,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_769",
+        "logos-nix": "logos-nix_770",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -38761,7 +38802,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_813",
+        "logos-nix": "logos-nix_814",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -38838,7 +38879,7 @@
     "logos-view-module-runtime_20": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_82",
-        "logos-nix": "logos-nix_841",
+        "logos-nix": "logos-nix_842",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -38869,7 +38910,7 @@
     "logos-view-module-runtime_21": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_84",
-        "logos-nix": "logos-nix_874",
+        "logos-nix": "logos-nix_875",
         "logos-protocol": "logos-protocol_26",
         "logos-qt-sdk": "logos-qt-sdk_20",
         "nixpkgs": [
@@ -39084,7 +39125,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_339",
+        "logos-nix": "logos-nix_340",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -39128,7 +39169,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_383",
+        "logos-nix": "logos-nix_384",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -39347,7 +39388,7 @@
     },
     "nix-bundle-appimage_15": {
       "inputs": {
-        "logos-nix": "logos-nix_333",
+        "logos-nix": "logos-nix_334",
         "nix-bundle-dir": "nix-bundle-dir_50",
         "nixpkgs": [
           "package_downloader",
@@ -39382,7 +39423,7 @@
     },
     "nix-bundle-appimage_16": {
       "inputs": {
-        "logos-nix": "logos-nix_350",
+        "logos-nix": "logos-nix_351",
         "nix-bundle-dir": "nix-bundle-dir_54",
         "nixpkgs": [
           "package_downloader",
@@ -39416,7 +39457,7 @@
     },
     "nix-bundle-appimage_17": {
       "inputs": {
-        "logos-nix": "logos-nix_377",
+        "logos-nix": "logos-nix_378",
         "nix-bundle-dir": "nix-bundle-dir_57",
         "nixpkgs": [
           "package_downloader",
@@ -39452,7 +39493,7 @@
     },
     "nix-bundle-appimage_18": {
       "inputs": {
-        "logos-nix": "logos-nix_394",
+        "logos-nix": "logos-nix_395",
         "nix-bundle-dir": "nix-bundle-dir_61",
         "nixpkgs": [
           "package_downloader",
@@ -39487,7 +39528,7 @@
     },
     "nix-bundle-appimage_19": {
       "inputs": {
-        "logos-nix": "logos-nix_405",
+        "logos-nix": "logos-nix_406",
         "nix-bundle-dir": "nix-bundle-dir_64",
         "nixpkgs": [
           "package_downloader",
@@ -39552,7 +39593,7 @@
     },
     "nix-bundle-appimage_20": {
       "inputs": {
-        "logos-nix": "logos-nix_422",
+        "logos-nix": "logos-nix_423",
         "nix-bundle-dir": "nix-bundle-dir_68",
         "nixpkgs": [
           "package_downloader",
@@ -39583,7 +39624,7 @@
     },
     "nix-bundle-appimage_21": {
       "inputs": {
-        "logos-nix": "logos-nix_463",
+        "logos-nix": "logos-nix_464",
         "nix-bundle-dir": "nix-bundle-dir_71",
         "nixpkgs": [
           "package_downloader",
@@ -39619,7 +39660,7 @@
     },
     "nix-bundle-appimage_22": {
       "inputs": {
-        "logos-nix": "logos-nix_480",
+        "logos-nix": "logos-nix_481",
         "nix-bundle-dir": "nix-bundle-dir_75",
         "nixpkgs": [
           "package_downloader",
@@ -39654,7 +39695,7 @@
     },
     "nix-bundle-appimage_23": {
       "inputs": {
-        "logos-nix": "logos-nix_507",
+        "logos-nix": "logos-nix_508",
         "nix-bundle-dir": "nix-bundle-dir_78",
         "nixpkgs": [
           "package_downloader",
@@ -39691,7 +39732,7 @@
     },
     "nix-bundle-appimage_24": {
       "inputs": {
-        "logos-nix": "logos-nix_524",
+        "logos-nix": "logos-nix_525",
         "nix-bundle-dir": "nix-bundle-dir_82",
         "nixpkgs": [
           "package_downloader",
@@ -39727,7 +39768,7 @@
     },
     "nix-bundle-appimage_25": {
       "inputs": {
-        "logos-nix": "logos-nix_535",
+        "logos-nix": "logos-nix_536",
         "nix-bundle-dir": "nix-bundle-dir_85",
         "nixpkgs": [
           "package_downloader",
@@ -39760,7 +39801,7 @@
     },
     "nix-bundle-appimage_26": {
       "inputs": {
-        "logos-nix": "logos-nix_552",
+        "logos-nix": "logos-nix_553",
         "nix-bundle-dir": "nix-bundle-dir_89",
         "nixpkgs": [
           "package_downloader",
@@ -39792,7 +39833,7 @@
     },
     "nix-bundle-appimage_27": {
       "inputs": {
-        "logos-nix": "logos-nix_566",
+        "logos-nix": "logos-nix_567",
         "nix-bundle-dir": "nix-bundle-dir_92",
         "nixpkgs": [
           "package_downloader",
@@ -39821,7 +39862,7 @@
     },
     "nix-bundle-appimage_28": {
       "inputs": {
-        "logos-nix": "logos-nix_585",
+        "logos-nix": "logos-nix_586",
         "nix-bundle-dir": "nix-bundle-dir_96",
         "nixpkgs": [
           "package_downloader",
@@ -39849,7 +39890,7 @@
     },
     "nix-bundle-appimage_29": {
       "inputs": {
-        "logos-nix": "logos-nix_593",
+        "logos-nix": "logos-nix_594",
         "nix-bundle-dir": "nix-bundle-dir_99",
         "nixpkgs": [
           "package_downloader",
@@ -39910,7 +39951,7 @@
     },
     "nix-bundle-appimage_30": {
       "inputs": {
-        "logos-nix": "logos-nix_633",
+        "logos-nix": "logos-nix_634",
         "nix-bundle-dir": "nix-bundle-dir_101",
         "nixpkgs": [
           "package_manager",
@@ -39945,7 +39986,7 @@
     },
     "nix-bundle-appimage_31": {
       "inputs": {
-        "logos-nix": "logos-nix_650",
+        "logos-nix": "logos-nix_651",
         "nix-bundle-dir": "nix-bundle-dir_105",
         "nixpkgs": [
           "package_manager",
@@ -39979,7 +40020,7 @@
     },
     "nix-bundle-appimage_32": {
       "inputs": {
-        "logos-nix": "logos-nix_677",
+        "logos-nix": "logos-nix_678",
         "nix-bundle-dir": "nix-bundle-dir_108",
         "nixpkgs": [
           "package_manager",
@@ -40015,7 +40056,7 @@
     },
     "nix-bundle-appimage_33": {
       "inputs": {
-        "logos-nix": "logos-nix_694",
+        "logos-nix": "logos-nix_695",
         "nix-bundle-dir": "nix-bundle-dir_112",
         "nixpkgs": [
           "package_manager",
@@ -40050,7 +40091,7 @@
     },
     "nix-bundle-appimage_34": {
       "inputs": {
-        "logos-nix": "logos-nix_705",
+        "logos-nix": "logos-nix_706",
         "nix-bundle-dir": "nix-bundle-dir_115",
         "nixpkgs": [
           "package_manager",
@@ -40082,7 +40123,7 @@
     },
     "nix-bundle-appimage_35": {
       "inputs": {
-        "logos-nix": "logos-nix_722",
+        "logos-nix": "logos-nix_723",
         "nix-bundle-dir": "nix-bundle-dir_119",
         "nixpkgs": [
           "package_manager",
@@ -40113,7 +40154,7 @@
     },
     "nix-bundle-appimage_36": {
       "inputs": {
-        "logos-nix": "logos-nix_763",
+        "logos-nix": "logos-nix_764",
         "nix-bundle-dir": "nix-bundle-dir_122",
         "nixpkgs": [
           "package_manager",
@@ -40149,7 +40190,7 @@
     },
     "nix-bundle-appimage_37": {
       "inputs": {
-        "logos-nix": "logos-nix_780",
+        "logos-nix": "logos-nix_781",
         "nix-bundle-dir": "nix-bundle-dir_126",
         "nixpkgs": [
           "package_manager",
@@ -40184,7 +40225,7 @@
     },
     "nix-bundle-appimage_38": {
       "inputs": {
-        "logos-nix": "logos-nix_807",
+        "logos-nix": "logos-nix_808",
         "nix-bundle-dir": "nix-bundle-dir_129",
         "nixpkgs": [
           "package_manager",
@@ -40221,7 +40262,7 @@
     },
     "nix-bundle-appimage_39": {
       "inputs": {
-        "logos-nix": "logos-nix_824",
+        "logos-nix": "logos-nix_825",
         "nix-bundle-dir": "nix-bundle-dir_133",
         "nixpkgs": [
           "package_manager",
@@ -40291,7 +40332,7 @@
     },
     "nix-bundle-appimage_40": {
       "inputs": {
-        "logos-nix": "logos-nix_835",
+        "logos-nix": "logos-nix_836",
         "nix-bundle-dir": "nix-bundle-dir_136",
         "nixpkgs": [
           "package_manager",
@@ -40324,7 +40365,7 @@
     },
     "nix-bundle-appimage_41": {
       "inputs": {
-        "logos-nix": "logos-nix_852",
+        "logos-nix": "logos-nix_853",
         "nix-bundle-dir": "nix-bundle-dir_140",
         "nixpkgs": [
           "package_manager",
@@ -40356,7 +40397,7 @@
     },
     "nix-bundle-appimage_42": {
       "inputs": {
-        "logos-nix": "logos-nix_866",
+        "logos-nix": "logos-nix_867",
         "nix-bundle-dir": "nix-bundle-dir_143",
         "nixpkgs": [
           "package_manager",
@@ -40385,7 +40426,7 @@
     },
     "nix-bundle-appimage_43": {
       "inputs": {
-        "logos-nix": "logos-nix_885",
+        "logos-nix": "logos-nix_886",
         "nix-bundle-dir": "nix-bundle-dir_147",
         "nixpkgs": [
           "package_manager",
@@ -40413,7 +40454,7 @@
     },
     "nix-bundle-appimage_44": {
       "inputs": {
-        "logos-nix": "logos-nix_893",
+        "logos-nix": "logos-nix_894",
         "nix-bundle-dir": "nix-bundle-dir_150",
         "nixpkgs": [
           "package_manager",
@@ -40670,7 +40711,7 @@
     },
     "nix-bundle-dir_100": {
       "inputs": {
-        "logos-nix": "logos-nix_595",
+        "logos-nix": "logos-nix_596",
         "nixpkgs": [
           "package_downloader",
           "logos-package-downloader",
@@ -40695,7 +40736,7 @@
     },
     "nix-bundle-dir_101": {
       "inputs": {
-        "logos-nix": "logos-nix_634",
+        "logos-nix": "logos-nix_635",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -40728,7 +40769,7 @@
     },
     "nix-bundle-dir_102": {
       "inputs": {
-        "logos-nix": "logos-nix_635",
+        "logos-nix": "logos-nix_636",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -40762,7 +40803,7 @@
     },
     "nix-bundle-dir_103": {
       "inputs": {
-        "logos-nix": "logos-nix_642",
+        "logos-nix": "logos-nix_643",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -40795,7 +40836,7 @@
     },
     "nix-bundle-dir_104": {
       "inputs": {
-        "logos-nix": "logos-nix_646",
+        "logos-nix": "logos-nix_647",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -40827,7 +40868,7 @@
     },
     "nix-bundle-dir_105": {
       "inputs": {
-        "logos-nix": "logos-nix_651",
+        "logos-nix": "logos-nix_652",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -40859,7 +40900,7 @@
     },
     "nix-bundle-dir_106": {
       "inputs": {
-        "logos-nix": "logos-nix_652",
+        "logos-nix": "logos-nix_653",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -40892,7 +40933,7 @@
     },
     "nix-bundle-dir_107": {
       "inputs": {
-        "logos-nix": "logos-nix_655",
+        "logos-nix": "logos-nix_656",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -40925,7 +40966,7 @@
     },
     "nix-bundle-dir_108": {
       "inputs": {
-        "logos-nix": "logos-nix_678",
+        "logos-nix": "logos-nix_679",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -40959,7 +41000,7 @@
     },
     "nix-bundle-dir_109": {
       "inputs": {
-        "logos-nix": "logos-nix_679",
+        "logos-nix": "logos-nix_680",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41026,7 +41067,7 @@
     },
     "nix-bundle-dir_110": {
       "inputs": {
-        "logos-nix": "logos-nix_686",
+        "logos-nix": "logos-nix_687",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41060,7 +41101,7 @@
     },
     "nix-bundle-dir_111": {
       "inputs": {
-        "logos-nix": "logos-nix_690",
+        "logos-nix": "logos-nix_691",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41093,7 +41134,7 @@
     },
     "nix-bundle-dir_112": {
       "inputs": {
-        "logos-nix": "logos-nix_695",
+        "logos-nix": "logos-nix_696",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41126,7 +41167,7 @@
     },
     "nix-bundle-dir_113": {
       "inputs": {
-        "logos-nix": "logos-nix_696",
+        "logos-nix": "logos-nix_697",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41160,7 +41201,7 @@
     },
     "nix-bundle-dir_114": {
       "inputs": {
-        "logos-nix": "logos-nix_699",
+        "logos-nix": "logos-nix_700",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41194,7 +41235,7 @@
     },
     "nix-bundle-dir_115": {
       "inputs": {
-        "logos-nix": "logos-nix_706",
+        "logos-nix": "logos-nix_707",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41224,7 +41265,7 @@
     },
     "nix-bundle-dir_116": {
       "inputs": {
-        "logos-nix": "logos-nix_707",
+        "logos-nix": "logos-nix_708",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41255,7 +41296,7 @@
     },
     "nix-bundle-dir_117": {
       "inputs": {
-        "logos-nix": "logos-nix_714",
+        "logos-nix": "logos-nix_715",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41285,7 +41326,7 @@
     },
     "nix-bundle-dir_118": {
       "inputs": {
-        "logos-nix": "logos-nix_718",
+        "logos-nix": "logos-nix_719",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41314,7 +41355,7 @@
     },
     "nix-bundle-dir_119": {
       "inputs": {
-        "logos-nix": "logos-nix_723",
+        "logos-nix": "logos-nix_724",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41375,7 +41416,7 @@
     },
     "nix-bundle-dir_120": {
       "inputs": {
-        "logos-nix": "logos-nix_724",
+        "logos-nix": "logos-nix_725",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41405,7 +41446,7 @@
     },
     "nix-bundle-dir_121": {
       "inputs": {
-        "logos-nix": "logos-nix_727",
+        "logos-nix": "logos-nix_728",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41435,7 +41476,7 @@
     },
     "nix-bundle-dir_122": {
       "inputs": {
-        "logos-nix": "logos-nix_764",
+        "logos-nix": "logos-nix_765",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41469,7 +41510,7 @@
     },
     "nix-bundle-dir_123": {
       "inputs": {
-        "logos-nix": "logos-nix_765",
+        "logos-nix": "logos-nix_766",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41504,7 +41545,7 @@
     },
     "nix-bundle-dir_124": {
       "inputs": {
-        "logos-nix": "logos-nix_772",
+        "logos-nix": "logos-nix_773",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41538,7 +41579,7 @@
     },
     "nix-bundle-dir_125": {
       "inputs": {
-        "logos-nix": "logos-nix_776",
+        "logos-nix": "logos-nix_777",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41571,7 +41612,7 @@
     },
     "nix-bundle-dir_126": {
       "inputs": {
-        "logos-nix": "logos-nix_781",
+        "logos-nix": "logos-nix_782",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41604,7 +41645,7 @@
     },
     "nix-bundle-dir_127": {
       "inputs": {
-        "logos-nix": "logos-nix_782",
+        "logos-nix": "logos-nix_783",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41638,7 +41679,7 @@
     },
     "nix-bundle-dir_128": {
       "inputs": {
-        "logos-nix": "logos-nix_785",
+        "logos-nix": "logos-nix_786",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41672,7 +41713,7 @@
     },
     "nix-bundle-dir_129": {
       "inputs": {
-        "logos-nix": "logos-nix_808",
+        "logos-nix": "logos-nix_809",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41740,7 +41781,7 @@
     },
     "nix-bundle-dir_130": {
       "inputs": {
-        "logos-nix": "logos-nix_809",
+        "logos-nix": "logos-nix_810",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41776,7 +41817,7 @@
     },
     "nix-bundle-dir_131": {
       "inputs": {
-        "logos-nix": "logos-nix_816",
+        "logos-nix": "logos-nix_817",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41811,7 +41852,7 @@
     },
     "nix-bundle-dir_132": {
       "inputs": {
-        "logos-nix": "logos-nix_820",
+        "logos-nix": "logos-nix_821",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41845,7 +41886,7 @@
     },
     "nix-bundle-dir_133": {
       "inputs": {
-        "logos-nix": "logos-nix_825",
+        "logos-nix": "logos-nix_826",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41879,7 +41920,7 @@
     },
     "nix-bundle-dir_134": {
       "inputs": {
-        "logos-nix": "logos-nix_826",
+        "logos-nix": "logos-nix_827",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41914,7 +41955,7 @@
     },
     "nix-bundle-dir_135": {
       "inputs": {
-        "logos-nix": "logos-nix_829",
+        "logos-nix": "logos-nix_830",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41949,7 +41990,7 @@
     },
     "nix-bundle-dir_136": {
       "inputs": {
-        "logos-nix": "logos-nix_836",
+        "logos-nix": "logos-nix_837",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -41980,7 +42021,7 @@
     },
     "nix-bundle-dir_137": {
       "inputs": {
-        "logos-nix": "logos-nix_837",
+        "logos-nix": "logos-nix_838",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -42012,7 +42053,7 @@
     },
     "nix-bundle-dir_138": {
       "inputs": {
-        "logos-nix": "logos-nix_844",
+        "logos-nix": "logos-nix_845",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -42043,7 +42084,7 @@
     },
     "nix-bundle-dir_139": {
       "inputs": {
-        "logos-nix": "logos-nix_848",
+        "logos-nix": "logos-nix_849",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -42106,7 +42147,7 @@
     },
     "nix-bundle-dir_140": {
       "inputs": {
-        "logos-nix": "logos-nix_853",
+        "logos-nix": "logos-nix_854",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -42136,7 +42177,7 @@
     },
     "nix-bundle-dir_141": {
       "inputs": {
-        "logos-nix": "logos-nix_854",
+        "logos-nix": "logos-nix_855",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -42167,7 +42208,7 @@
     },
     "nix-bundle-dir_142": {
       "inputs": {
-        "logos-nix": "logos-nix_857",
+        "logos-nix": "logos-nix_858",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -42198,7 +42239,7 @@
     },
     "nix-bundle-dir_143": {
       "inputs": {
-        "logos-nix": "logos-nix_867",
+        "logos-nix": "logos-nix_868",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -42225,7 +42266,7 @@
     },
     "nix-bundle-dir_144": {
       "inputs": {
-        "logos-nix": "logos-nix_868",
+        "logos-nix": "logos-nix_869",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -42253,7 +42294,7 @@
     },
     "nix-bundle-dir_145": {
       "inputs": {
-        "logos-nix": "logos-nix_877",
+        "logos-nix": "logos-nix_878",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -42280,7 +42321,7 @@
     },
     "nix-bundle-dir_146": {
       "inputs": {
-        "logos-nix": "logos-nix_881",
+        "logos-nix": "logos-nix_882",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -42306,7 +42347,7 @@
     },
     "nix-bundle-dir_147": {
       "inputs": {
-        "logos-nix": "logos-nix_886",
+        "logos-nix": "logos-nix_887",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -42332,7 +42373,7 @@
     },
     "nix-bundle-dir_148": {
       "inputs": {
-        "logos-nix": "logos-nix_887",
+        "logos-nix": "logos-nix_888",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -42359,7 +42400,7 @@
     },
     "nix-bundle-dir_149": {
       "inputs": {
-        "logos-nix": "logos-nix_890",
+        "logos-nix": "logos-nix_891",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -42415,7 +42456,7 @@
     },
     "nix-bundle-dir_150": {
       "inputs": {
-        "logos-nix": "logos-nix_894",
+        "logos-nix": "logos-nix_895",
         "nixpkgs": [
           "package_manager",
           "logos-package-manager",
@@ -42439,7 +42480,7 @@
     },
     "nix-bundle-dir_151": {
       "inputs": {
-        "logos-nix": "logos-nix_895",
+        "logos-nix": "logos-nix_896",
         "nixpkgs": [
           "package_manager",
           "logos-package-manager",
@@ -43621,7 +43662,7 @@
     },
     "nix-bundle-dir_50": {
       "inputs": {
-        "logos-nix": "logos-nix_334",
+        "logos-nix": "logos-nix_335",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -43654,7 +43695,7 @@
     },
     "nix-bundle-dir_51": {
       "inputs": {
-        "logos-nix": "logos-nix_335",
+        "logos-nix": "logos-nix_336",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -43688,7 +43729,7 @@
     },
     "nix-bundle-dir_52": {
       "inputs": {
-        "logos-nix": "logos-nix_342",
+        "logos-nix": "logos-nix_343",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -43721,7 +43762,7 @@
     },
     "nix-bundle-dir_53": {
       "inputs": {
-        "logos-nix": "logos-nix_346",
+        "logos-nix": "logos-nix_347",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -43753,7 +43794,7 @@
     },
     "nix-bundle-dir_54": {
       "inputs": {
-        "logos-nix": "logos-nix_351",
+        "logos-nix": "logos-nix_352",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -43785,7 +43826,7 @@
     },
     "nix-bundle-dir_55": {
       "inputs": {
-        "logos-nix": "logos-nix_352",
+        "logos-nix": "logos-nix_353",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -43818,7 +43859,7 @@
     },
     "nix-bundle-dir_56": {
       "inputs": {
-        "logos-nix": "logos-nix_355",
+        "logos-nix": "logos-nix_356",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -43851,7 +43892,7 @@
     },
     "nix-bundle-dir_57": {
       "inputs": {
-        "logos-nix": "logos-nix_378",
+        "logos-nix": "logos-nix_379",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -43885,7 +43926,7 @@
     },
     "nix-bundle-dir_58": {
       "inputs": {
-        "logos-nix": "logos-nix_379",
+        "logos-nix": "logos-nix_380",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -43920,7 +43961,7 @@
     },
     "nix-bundle-dir_59": {
       "inputs": {
-        "logos-nix": "logos-nix_386",
+        "logos-nix": "logos-nix_387",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -43986,7 +44027,7 @@
     },
     "nix-bundle-dir_60": {
       "inputs": {
-        "logos-nix": "logos-nix_390",
+        "logos-nix": "logos-nix_391",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44019,7 +44060,7 @@
     },
     "nix-bundle-dir_61": {
       "inputs": {
-        "logos-nix": "logos-nix_395",
+        "logos-nix": "logos-nix_396",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44052,7 +44093,7 @@
     },
     "nix-bundle-dir_62": {
       "inputs": {
-        "logos-nix": "logos-nix_396",
+        "logos-nix": "logos-nix_397",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44086,7 +44127,7 @@
     },
     "nix-bundle-dir_63": {
       "inputs": {
-        "logos-nix": "logos-nix_399",
+        "logos-nix": "logos-nix_400",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44120,7 +44161,7 @@
     },
     "nix-bundle-dir_64": {
       "inputs": {
-        "logos-nix": "logos-nix_406",
+        "logos-nix": "logos-nix_407",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44150,7 +44191,7 @@
     },
     "nix-bundle-dir_65": {
       "inputs": {
-        "logos-nix": "logos-nix_407",
+        "logos-nix": "logos-nix_408",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44181,7 +44222,7 @@
     },
     "nix-bundle-dir_66": {
       "inputs": {
-        "logos-nix": "logos-nix_414",
+        "logos-nix": "logos-nix_415",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44211,7 +44252,7 @@
     },
     "nix-bundle-dir_67": {
       "inputs": {
-        "logos-nix": "logos-nix_418",
+        "logos-nix": "logos-nix_419",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44240,7 +44281,7 @@
     },
     "nix-bundle-dir_68": {
       "inputs": {
-        "logos-nix": "logos-nix_423",
+        "logos-nix": "logos-nix_424",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44269,7 +44310,7 @@
     },
     "nix-bundle-dir_69": {
       "inputs": {
-        "logos-nix": "logos-nix_424",
+        "logos-nix": "logos-nix_425",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44331,7 +44372,7 @@
     },
     "nix-bundle-dir_70": {
       "inputs": {
-        "logos-nix": "logos-nix_427",
+        "logos-nix": "logos-nix_428",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44361,7 +44402,7 @@
     },
     "nix-bundle-dir_71": {
       "inputs": {
-        "logos-nix": "logos-nix_464",
+        "logos-nix": "logos-nix_465",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44395,7 +44436,7 @@
     },
     "nix-bundle-dir_72": {
       "inputs": {
-        "logos-nix": "logos-nix_465",
+        "logos-nix": "logos-nix_466",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44430,7 +44471,7 @@
     },
     "nix-bundle-dir_73": {
       "inputs": {
-        "logos-nix": "logos-nix_472",
+        "logos-nix": "logos-nix_473",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44464,7 +44505,7 @@
     },
     "nix-bundle-dir_74": {
       "inputs": {
-        "logos-nix": "logos-nix_476",
+        "logos-nix": "logos-nix_477",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44497,7 +44538,7 @@
     },
     "nix-bundle-dir_75": {
       "inputs": {
-        "logos-nix": "logos-nix_481",
+        "logos-nix": "logos-nix_482",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44530,7 +44571,7 @@
     },
     "nix-bundle-dir_76": {
       "inputs": {
-        "logos-nix": "logos-nix_482",
+        "logos-nix": "logos-nix_483",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44564,7 +44605,7 @@
     },
     "nix-bundle-dir_77": {
       "inputs": {
-        "logos-nix": "logos-nix_485",
+        "logos-nix": "logos-nix_486",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44598,7 +44639,7 @@
     },
     "nix-bundle-dir_78": {
       "inputs": {
-        "logos-nix": "logos-nix_508",
+        "logos-nix": "logos-nix_509",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44633,7 +44674,7 @@
     },
     "nix-bundle-dir_79": {
       "inputs": {
-        "logos-nix": "logos-nix_509",
+        "logos-nix": "logos-nix_510",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44702,7 +44743,7 @@
     },
     "nix-bundle-dir_80": {
       "inputs": {
-        "logos-nix": "logos-nix_516",
+        "logos-nix": "logos-nix_517",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44737,7 +44778,7 @@
     },
     "nix-bundle-dir_81": {
       "inputs": {
-        "logos-nix": "logos-nix_520",
+        "logos-nix": "logos-nix_521",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44771,7 +44812,7 @@
     },
     "nix-bundle-dir_82": {
       "inputs": {
-        "logos-nix": "logos-nix_525",
+        "logos-nix": "logos-nix_526",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44805,7 +44846,7 @@
     },
     "nix-bundle-dir_83": {
       "inputs": {
-        "logos-nix": "logos-nix_526",
+        "logos-nix": "logos-nix_527",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44840,7 +44881,7 @@
     },
     "nix-bundle-dir_84": {
       "inputs": {
-        "logos-nix": "logos-nix_529",
+        "logos-nix": "logos-nix_530",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44875,7 +44916,7 @@
     },
     "nix-bundle-dir_85": {
       "inputs": {
-        "logos-nix": "logos-nix_536",
+        "logos-nix": "logos-nix_537",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44906,7 +44947,7 @@
     },
     "nix-bundle-dir_86": {
       "inputs": {
-        "logos-nix": "logos-nix_537",
+        "logos-nix": "logos-nix_538",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44938,7 +44979,7 @@
     },
     "nix-bundle-dir_87": {
       "inputs": {
-        "logos-nix": "logos-nix_544",
+        "logos-nix": "logos-nix_545",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44969,7 +45010,7 @@
     },
     "nix-bundle-dir_88": {
       "inputs": {
-        "logos-nix": "logos-nix_548",
+        "logos-nix": "logos-nix_549",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -44999,7 +45040,7 @@
     },
     "nix-bundle-dir_89": {
       "inputs": {
-        "logos-nix": "logos-nix_553",
+        "logos-nix": "logos-nix_554",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -45063,7 +45104,7 @@
     },
     "nix-bundle-dir_90": {
       "inputs": {
-        "logos-nix": "logos-nix_554",
+        "logos-nix": "logos-nix_555",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -45094,7 +45135,7 @@
     },
     "nix-bundle-dir_91": {
       "inputs": {
-        "logos-nix": "logos-nix_557",
+        "logos-nix": "logos-nix_558",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -45125,7 +45166,7 @@
     },
     "nix-bundle-dir_92": {
       "inputs": {
-        "logos-nix": "logos-nix_567",
+        "logos-nix": "logos-nix_568",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -45152,7 +45193,7 @@
     },
     "nix-bundle-dir_93": {
       "inputs": {
-        "logos-nix": "logos-nix_568",
+        "logos-nix": "logos-nix_569",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -45180,7 +45221,7 @@
     },
     "nix-bundle-dir_94": {
       "inputs": {
-        "logos-nix": "logos-nix_577",
+        "logos-nix": "logos-nix_578",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -45207,7 +45248,7 @@
     },
     "nix-bundle-dir_95": {
       "inputs": {
-        "logos-nix": "logos-nix_581",
+        "logos-nix": "logos-nix_582",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -45233,7 +45274,7 @@
     },
     "nix-bundle-dir_96": {
       "inputs": {
-        "logos-nix": "logos-nix_586",
+        "logos-nix": "logos-nix_587",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -45259,7 +45300,7 @@
     },
     "nix-bundle-dir_97": {
       "inputs": {
-        "logos-nix": "logos-nix_587",
+        "logos-nix": "logos-nix_588",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -45286,7 +45327,7 @@
     },
     "nix-bundle-dir_98": {
       "inputs": {
-        "logos-nix": "logos-nix_590",
+        "logos-nix": "logos-nix_591",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -45313,7 +45354,7 @@
     },
     "nix-bundle-dir_99": {
       "inputs": {
-        "logos-nix": "logos-nix_594",
+        "logos-nix": "logos-nix_595",
         "nixpkgs": [
           "package_downloader",
           "logos-package-downloader",
@@ -45776,8 +45817,8 @@
     },
     "nix-bundle-lgx_22": {
       "inputs": {
-        "logos-nix": "logos-nix_340",
-        "logos-package": "logos-package_37",
+        "logos-nix": "logos-nix_341",
+        "logos-package": "logos-package_38",
         "nix-bundle-dir": "nix-bundle-dir_52",
         "nixpkgs": [
           "package_downloader",
@@ -45809,8 +45850,8 @@
     },
     "nix-bundle-lgx_23": {
       "inputs": {
-        "logos-nix": "logos-nix_344",
-        "logos-package": "logos-package_38",
+        "logos-nix": "logos-nix_345",
+        "logos-package": "logos-package_39",
         "nix-bundle-dir": "nix-bundle-dir_53",
         "nixpkgs": [
           "package_downloader",
@@ -45842,8 +45883,8 @@
     },
     "nix-bundle-lgx_24": {
       "inputs": {
-        "logos-nix": "logos-nix_353",
-        "logos-package": "logos-package_40",
+        "logos-nix": "logos-nix_354",
+        "logos-package": "logos-package_41",
         "nix-bundle-dir": "nix-bundle-dir_56",
         "nixpkgs": [
           "package_downloader",
@@ -45876,8 +45917,8 @@
     },
     "nix-bundle-lgx_25": {
       "inputs": {
-        "logos-nix": "logos-nix_384",
-        "logos-package": "logos-package_42",
+        "logos-nix": "logos-nix_385",
+        "logos-package": "logos-package_43",
         "nix-bundle-dir": "nix-bundle-dir_59",
         "nixpkgs": [
           "package_downloader",
@@ -45910,8 +45951,8 @@
     },
     "nix-bundle-lgx_26": {
       "inputs": {
-        "logos-nix": "logos-nix_388",
-        "logos-package": "logos-package_43",
+        "logos-nix": "logos-nix_389",
+        "logos-package": "logos-package_44",
         "nix-bundle-dir": "nix-bundle-dir_60",
         "nixpkgs": [
           "package_downloader",
@@ -45944,8 +45985,8 @@
     },
     "nix-bundle-lgx_27": {
       "inputs": {
-        "logos-nix": "logos-nix_397",
-        "logos-package": "logos-package_45",
+        "logos-nix": "logos-nix_398",
+        "logos-package": "logos-package_46",
         "nix-bundle-dir": "nix-bundle-dir_63",
         "nixpkgs": [
           "package_downloader",
@@ -45979,8 +46020,8 @@
     },
     "nix-bundle-lgx_28": {
       "inputs": {
-        "logos-nix": "logos-nix_412",
-        "logos-package": "logos-package_47",
+        "logos-nix": "logos-nix_413",
+        "logos-package": "logos-package_48",
         "nix-bundle-dir": "nix-bundle-dir_66",
         "nixpkgs": [
           "package_downloader",
@@ -46010,8 +46051,8 @@
     },
     "nix-bundle-lgx_29": {
       "inputs": {
-        "logos-nix": "logos-nix_416",
-        "logos-package": "logos-package_48",
+        "logos-nix": "logos-nix_417",
+        "logos-package": "logos-package_49",
         "nix-bundle-dir": "nix-bundle-dir_67",
         "nixpkgs": [
           "package_downloader",
@@ -46073,8 +46114,8 @@
     },
     "nix-bundle-lgx_30": {
       "inputs": {
-        "logos-nix": "logos-nix_425",
-        "logos-package": "logos-package_50",
+        "logos-nix": "logos-nix_426",
+        "logos-package": "logos-package_51",
         "nix-bundle-dir": "nix-bundle-dir_70",
         "nixpkgs": [
           "package_downloader",
@@ -46104,8 +46145,8 @@
     },
     "nix-bundle-lgx_31": {
       "inputs": {
-        "logos-nix": "logos-nix_470",
-        "logos-package": "logos-package_52",
+        "logos-nix": "logos-nix_471",
+        "logos-package": "logos-package_53",
         "nix-bundle-dir": "nix-bundle-dir_73",
         "nixpkgs": [
           "package_downloader",
@@ -46138,8 +46179,8 @@
     },
     "nix-bundle-lgx_32": {
       "inputs": {
-        "logos-nix": "logos-nix_474",
-        "logos-package": "logos-package_53",
+        "logos-nix": "logos-nix_475",
+        "logos-package": "logos-package_54",
         "nix-bundle-dir": "nix-bundle-dir_74",
         "nixpkgs": [
           "package_downloader",
@@ -46172,8 +46213,8 @@
     },
     "nix-bundle-lgx_33": {
       "inputs": {
-        "logos-nix": "logos-nix_483",
-        "logos-package": "logos-package_55",
+        "logos-nix": "logos-nix_484",
+        "logos-package": "logos-package_56",
         "nix-bundle-dir": "nix-bundle-dir_77",
         "nixpkgs": [
           "package_downloader",
@@ -46207,8 +46248,8 @@
     },
     "nix-bundle-lgx_34": {
       "inputs": {
-        "logos-nix": "logos-nix_514",
-        "logos-package": "logos-package_57",
+        "logos-nix": "logos-nix_515",
+        "logos-package": "logos-package_58",
         "nix-bundle-dir": "nix-bundle-dir_80",
         "nixpkgs": [
           "package_downloader",
@@ -46242,8 +46283,8 @@
     },
     "nix-bundle-lgx_35": {
       "inputs": {
-        "logos-nix": "logos-nix_518",
-        "logos-package": "logos-package_58",
+        "logos-nix": "logos-nix_519",
+        "logos-package": "logos-package_59",
         "nix-bundle-dir": "nix-bundle-dir_81",
         "nixpkgs": [
           "package_downloader",
@@ -46277,8 +46318,8 @@
     },
     "nix-bundle-lgx_36": {
       "inputs": {
-        "logos-nix": "logos-nix_527",
-        "logos-package": "logos-package_60",
+        "logos-nix": "logos-nix_528",
+        "logos-package": "logos-package_61",
         "nix-bundle-dir": "nix-bundle-dir_84",
         "nixpkgs": [
           "package_downloader",
@@ -46313,8 +46354,8 @@
     },
     "nix-bundle-lgx_37": {
       "inputs": {
-        "logos-nix": "logos-nix_542",
-        "logos-package": "logos-package_62",
+        "logos-nix": "logos-nix_543",
+        "logos-package": "logos-package_63",
         "nix-bundle-dir": "nix-bundle-dir_87",
         "nixpkgs": [
           "package_downloader",
@@ -46345,8 +46386,8 @@
     },
     "nix-bundle-lgx_38": {
       "inputs": {
-        "logos-nix": "logos-nix_546",
-        "logos-package": "logos-package_63",
+        "logos-nix": "logos-nix_547",
+        "logos-package": "logos-package_64",
         "nix-bundle-dir": "nix-bundle-dir_88",
         "nixpkgs": [
           "package_downloader",
@@ -46376,8 +46417,8 @@
     },
     "nix-bundle-lgx_39": {
       "inputs": {
-        "logos-nix": "logos-nix_555",
-        "logos-package": "logos-package_65",
+        "logos-nix": "logos-nix_556",
+        "logos-package": "logos-package_66",
         "nix-bundle-dir": "nix-bundle-dir_91",
         "nixpkgs": [
           "package_downloader",
@@ -46441,8 +46482,8 @@
     },
     "nix-bundle-lgx_40": {
       "inputs": {
-        "logos-nix": "logos-nix_575",
-        "logos-package": "logos-package_67",
+        "logos-nix": "logos-nix_576",
+        "logos-package": "logos-package_68",
         "nix-bundle-dir": "nix-bundle-dir_94",
         "nixpkgs": [
           "package_downloader",
@@ -46469,8 +46510,8 @@
     },
     "nix-bundle-lgx_41": {
       "inputs": {
-        "logos-nix": "logos-nix_579",
-        "logos-package": "logos-package_68",
+        "logos-nix": "logos-nix_580",
+        "logos-package": "logos-package_69",
         "nix-bundle-dir": "nix-bundle-dir_95",
         "nixpkgs": [
           "package_downloader",
@@ -46496,8 +46537,8 @@
     },
     "nix-bundle-lgx_42": {
       "inputs": {
-        "logos-nix": "logos-nix_588",
-        "logos-package": "logos-package_70",
+        "logos-nix": "logos-nix_589",
+        "logos-package": "logos-package_71",
         "nix-bundle-dir": "nix-bundle-dir_98",
         "nixpkgs": [
           "package_downloader",
@@ -46524,8 +46565,8 @@
     },
     "nix-bundle-lgx_43": {
       "inputs": {
-        "logos-nix": "logos-nix_640",
-        "logos-package": "logos-package_73",
+        "logos-nix": "logos-nix_641",
+        "logos-package": "logos-package_74",
         "nix-bundle-dir": "nix-bundle-dir_103",
         "nixpkgs": [
           "package_manager",
@@ -46557,8 +46598,8 @@
     },
     "nix-bundle-lgx_44": {
       "inputs": {
-        "logos-nix": "logos-nix_644",
-        "logos-package": "logos-package_74",
+        "logos-nix": "logos-nix_645",
+        "logos-package": "logos-package_75",
         "nix-bundle-dir": "nix-bundle-dir_104",
         "nixpkgs": [
           "package_manager",
@@ -46590,8 +46631,8 @@
     },
     "nix-bundle-lgx_45": {
       "inputs": {
-        "logos-nix": "logos-nix_653",
-        "logos-package": "logos-package_76",
+        "logos-nix": "logos-nix_654",
+        "logos-package": "logos-package_77",
         "nix-bundle-dir": "nix-bundle-dir_107",
         "nixpkgs": [
           "package_manager",
@@ -46624,8 +46665,8 @@
     },
     "nix-bundle-lgx_46": {
       "inputs": {
-        "logos-nix": "logos-nix_684",
-        "logos-package": "logos-package_78",
+        "logos-nix": "logos-nix_685",
+        "logos-package": "logos-package_79",
         "nix-bundle-dir": "nix-bundle-dir_110",
         "nixpkgs": [
           "package_manager",
@@ -46658,8 +46699,8 @@
     },
     "nix-bundle-lgx_47": {
       "inputs": {
-        "logos-nix": "logos-nix_688",
-        "logos-package": "logos-package_79",
+        "logos-nix": "logos-nix_689",
+        "logos-package": "logos-package_80",
         "nix-bundle-dir": "nix-bundle-dir_111",
         "nixpkgs": [
           "package_manager",
@@ -46692,8 +46733,8 @@
     },
     "nix-bundle-lgx_48": {
       "inputs": {
-        "logos-nix": "logos-nix_697",
-        "logos-package": "logos-package_81",
+        "logos-nix": "logos-nix_698",
+        "logos-package": "logos-package_82",
         "nix-bundle-dir": "nix-bundle-dir_114",
         "nixpkgs": [
           "package_manager",
@@ -46727,8 +46768,8 @@
     },
     "nix-bundle-lgx_49": {
       "inputs": {
-        "logos-nix": "logos-nix_712",
-        "logos-package": "logos-package_83",
+        "logos-nix": "logos-nix_713",
+        "logos-package": "logos-package_84",
         "nix-bundle-dir": "nix-bundle-dir_117",
         "nixpkgs": [
           "package_manager",
@@ -46791,8 +46832,8 @@
     },
     "nix-bundle-lgx_50": {
       "inputs": {
-        "logos-nix": "logos-nix_716",
-        "logos-package": "logos-package_84",
+        "logos-nix": "logos-nix_717",
+        "logos-package": "logos-package_85",
         "nix-bundle-dir": "nix-bundle-dir_118",
         "nixpkgs": [
           "package_manager",
@@ -46821,8 +46862,8 @@
     },
     "nix-bundle-lgx_51": {
       "inputs": {
-        "logos-nix": "logos-nix_725",
-        "logos-package": "logos-package_86",
+        "logos-nix": "logos-nix_726",
+        "logos-package": "logos-package_87",
         "nix-bundle-dir": "nix-bundle-dir_121",
         "nixpkgs": [
           "package_manager",
@@ -46852,8 +46893,8 @@
     },
     "nix-bundle-lgx_52": {
       "inputs": {
-        "logos-nix": "logos-nix_770",
-        "logos-package": "logos-package_88",
+        "logos-nix": "logos-nix_771",
+        "logos-package": "logos-package_89",
         "nix-bundle-dir": "nix-bundle-dir_124",
         "nixpkgs": [
           "package_manager",
@@ -46886,8 +46927,8 @@
     },
     "nix-bundle-lgx_53": {
       "inputs": {
-        "logos-nix": "logos-nix_774",
-        "logos-package": "logos-package_89",
+        "logos-nix": "logos-nix_775",
+        "logos-package": "logos-package_90",
         "nix-bundle-dir": "nix-bundle-dir_125",
         "nixpkgs": [
           "package_manager",
@@ -46920,8 +46961,8 @@
     },
     "nix-bundle-lgx_54": {
       "inputs": {
-        "logos-nix": "logos-nix_783",
-        "logos-package": "logos-package_91",
+        "logos-nix": "logos-nix_784",
+        "logos-package": "logos-package_92",
         "nix-bundle-dir": "nix-bundle-dir_128",
         "nixpkgs": [
           "package_manager",
@@ -46955,8 +46996,8 @@
     },
     "nix-bundle-lgx_55": {
       "inputs": {
-        "logos-nix": "logos-nix_814",
-        "logos-package": "logos-package_93",
+        "logos-nix": "logos-nix_815",
+        "logos-package": "logos-package_94",
         "nix-bundle-dir": "nix-bundle-dir_131",
         "nixpkgs": [
           "package_manager",
@@ -46990,8 +47031,8 @@
     },
     "nix-bundle-lgx_56": {
       "inputs": {
-        "logos-nix": "logos-nix_818",
-        "logos-package": "logos-package_94",
+        "logos-nix": "logos-nix_819",
+        "logos-package": "logos-package_95",
         "nix-bundle-dir": "nix-bundle-dir_132",
         "nixpkgs": [
           "package_manager",
@@ -47025,8 +47066,8 @@
     },
     "nix-bundle-lgx_57": {
       "inputs": {
-        "logos-nix": "logos-nix_827",
-        "logos-package": "logos-package_96",
+        "logos-nix": "logos-nix_828",
+        "logos-package": "logos-package_97",
         "nix-bundle-dir": "nix-bundle-dir_135",
         "nixpkgs": [
           "package_manager",
@@ -47061,8 +47102,8 @@
     },
     "nix-bundle-lgx_58": {
       "inputs": {
-        "logos-nix": "logos-nix_842",
-        "logos-package": "logos-package_98",
+        "logos-nix": "logos-nix_843",
+        "logos-package": "logos-package_99",
         "nix-bundle-dir": "nix-bundle-dir_138",
         "nixpkgs": [
           "package_manager",
@@ -47093,8 +47134,8 @@
     },
     "nix-bundle-lgx_59": {
       "inputs": {
-        "logos-nix": "logos-nix_846",
-        "logos-package": "logos-package_99",
+        "logos-nix": "logos-nix_847",
+        "logos-package": "logos-package_100",
         "nix-bundle-dir": "nix-bundle-dir_139",
         "nixpkgs": [
           "package_manager",
@@ -47158,8 +47199,8 @@
     },
     "nix-bundle-lgx_60": {
       "inputs": {
-        "logos-nix": "logos-nix_855",
-        "logos-package": "logos-package_101",
+        "logos-nix": "logos-nix_856",
+        "logos-package": "logos-package_102",
         "nix-bundle-dir": "nix-bundle-dir_142",
         "nixpkgs": [
           "package_manager",
@@ -47190,8 +47231,8 @@
     },
     "nix-bundle-lgx_61": {
       "inputs": {
-        "logos-nix": "logos-nix_875",
-        "logos-package": "logos-package_103",
+        "logos-nix": "logos-nix_876",
+        "logos-package": "logos-package_104",
         "nix-bundle-dir": "nix-bundle-dir_145",
         "nixpkgs": [
           "package_manager",
@@ -47218,8 +47259,8 @@
     },
     "nix-bundle-lgx_62": {
       "inputs": {
-        "logos-nix": "logos-nix_879",
-        "logos-package": "logos-package_104",
+        "logos-nix": "logos-nix_880",
+        "logos-package": "logos-package_105",
         "nix-bundle-dir": "nix-bundle-dir_146",
         "nixpkgs": [
           "package_manager",
@@ -47245,8 +47286,8 @@
     },
     "nix-bundle-lgx_63": {
       "inputs": {
-        "logos-nix": "logos-nix_888",
-        "logos-package": "logos-package_106",
+        "logos-nix": "logos-nix_889",
+        "logos-package": "logos-package_107",
         "nix-bundle-dir": "nix-bundle-dir_149",
         "nixpkgs": [
           "package_manager",
@@ -47394,7 +47435,7 @@
     },
     "nix-bundle-logos-module-install_10": {
       "inputs": {
-        "logos-nix": "logos-nix_419",
+        "logos-nix": "logos-nix_420",
         "logos-package-manager": "logos-package-manager_20",
         "nix-bundle-lgx": "nix-bundle-lgx_30",
         "nixpkgs": [
@@ -47424,7 +47465,7 @@
     },
     "nix-bundle-logos-module-install_11": {
       "inputs": {
-        "logos-nix": "logos-nix_477",
+        "logos-nix": "logos-nix_478",
         "logos-package-manager": "logos-package-manager_22",
         "nix-bundle-lgx": "nix-bundle-lgx_33",
         "nixpkgs": [
@@ -47458,7 +47499,7 @@
     },
     "nix-bundle-logos-module-install_12": {
       "inputs": {
-        "logos-nix": "logos-nix_521",
+        "logos-nix": "logos-nix_522",
         "logos-package-manager": "logos-package-manager_24",
         "nix-bundle-lgx": "nix-bundle-lgx_36",
         "nixpkgs": [
@@ -47493,7 +47534,7 @@
     },
     "nix-bundle-logos-module-install_13": {
       "inputs": {
-        "logos-nix": "logos-nix_549",
+        "logos-nix": "logos-nix_550",
         "logos-package-manager": "logos-package-manager_26",
         "nix-bundle-lgx": "nix-bundle-lgx_39",
         "nixpkgs": [
@@ -47524,7 +47565,7 @@
     },
     "nix-bundle-logos-module-install_14": {
       "inputs": {
-        "logos-nix": "logos-nix_582",
+        "logos-nix": "logos-nix_583",
         "logos-package-manager": "logos-package-manager_28",
         "nix-bundle-lgx": "nix-bundle-lgx_42",
         "nixpkgs": [
@@ -47551,7 +47592,7 @@
     },
     "nix-bundle-logos-module-install_15": {
       "inputs": {
-        "logos-nix": "logos-nix_647",
+        "logos-nix": "logos-nix_648",
         "logos-package-manager": "logos-package-manager_30",
         "nix-bundle-lgx": "nix-bundle-lgx_45",
         "nixpkgs": [
@@ -47584,7 +47625,7 @@
     },
     "nix-bundle-logos-module-install_16": {
       "inputs": {
-        "logos-nix": "logos-nix_691",
+        "logos-nix": "logos-nix_692",
         "logos-package-manager": "logos-package-manager_32",
         "nix-bundle-lgx": "nix-bundle-lgx_48",
         "nixpkgs": [
@@ -47618,7 +47659,7 @@
     },
     "nix-bundle-logos-module-install_17": {
       "inputs": {
-        "logos-nix": "logos-nix_719",
+        "logos-nix": "logos-nix_720",
         "logos-package-manager": "logos-package-manager_34",
         "nix-bundle-lgx": "nix-bundle-lgx_51",
         "nixpkgs": [
@@ -47648,7 +47689,7 @@
     },
     "nix-bundle-logos-module-install_18": {
       "inputs": {
-        "logos-nix": "logos-nix_777",
+        "logos-nix": "logos-nix_778",
         "logos-package-manager": "logos-package-manager_36",
         "nix-bundle-lgx": "nix-bundle-lgx_54",
         "nixpkgs": [
@@ -47682,7 +47723,7 @@
     },
     "nix-bundle-logos-module-install_19": {
       "inputs": {
-        "logos-nix": "logos-nix_821",
+        "logos-nix": "logos-nix_822",
         "logos-package-manager": "logos-package-manager_38",
         "nix-bundle-lgx": "nix-bundle-lgx_57",
         "nixpkgs": [
@@ -47750,7 +47791,7 @@
     },
     "nix-bundle-logos-module-install_20": {
       "inputs": {
-        "logos-nix": "logos-nix_849",
+        "logos-nix": "logos-nix_850",
         "logos-package-manager": "logos-package-manager_40",
         "nix-bundle-lgx": "nix-bundle-lgx_60",
         "nixpkgs": [
@@ -47781,7 +47822,7 @@
     },
     "nix-bundle-logos-module-install_21": {
       "inputs": {
-        "logos-nix": "logos-nix_882",
+        "logos-nix": "logos-nix_883",
         "logos-package-manager": "logos-package-manager_42",
         "nix-bundle-lgx": "nix-bundle-lgx_63",
         "nixpkgs": [
@@ -47960,7 +48001,7 @@
     },
     "nix-bundle-logos-module-install_8": {
       "inputs": {
-        "logos-nix": "logos-nix_347",
+        "logos-nix": "logos-nix_348",
         "logos-package-manager": "logos-package-manager_16",
         "nix-bundle-lgx": "nix-bundle-lgx_24",
         "nixpkgs": [
@@ -47993,7 +48034,7 @@
     },
     "nix-bundle-logos-module-install_9": {
       "inputs": {
-        "logos-nix": "logos-nix_391",
+        "logos-nix": "logos-nix_392",
         "logos-package-manager": "logos-package-manager_18",
         "nix-bundle-lgx": "nix-bundle-lgx_27",
         "nixpkgs": [
@@ -62169,6 +62210,22 @@
         "type": "github"
       }
     },
+    "nixpkgs_896": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_9": {
       "locked": {
         "lastModified": 1759036355,
@@ -62417,7 +62474,7 @@
     },
     "process-stats_10": {
       "inputs": {
-        "logos-nix": "logos-nix_408",
+        "logos-nix": "logos-nix_409",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -62447,7 +62504,7 @@
     },
     "process-stats_11": {
       "inputs": {
-        "logos-nix": "logos-nix_466",
+        "logos-nix": "logos-nix_467",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -62481,7 +62538,7 @@
     },
     "process-stats_12": {
       "inputs": {
-        "logos-nix": "logos-nix_510",
+        "logos-nix": "logos-nix_511",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -62516,7 +62573,7 @@
     },
     "process-stats_13": {
       "inputs": {
-        "logos-nix": "logos-nix_538",
+        "logos-nix": "logos-nix_539",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -62547,7 +62604,7 @@
     },
     "process-stats_14": {
       "inputs": {
-        "logos-nix": "logos-nix_571",
+        "logos-nix": "logos-nix_572",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -62574,7 +62631,7 @@
     },
     "process-stats_15": {
       "inputs": {
-        "logos-nix": "logos-nix_636",
+        "logos-nix": "logos-nix_637",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -62607,7 +62664,7 @@
     },
     "process-stats_16": {
       "inputs": {
-        "logos-nix": "logos-nix_680",
+        "logos-nix": "logos-nix_681",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -62641,7 +62698,7 @@
     },
     "process-stats_17": {
       "inputs": {
-        "logos-nix": "logos-nix_708",
+        "logos-nix": "logos-nix_709",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -62671,7 +62728,7 @@
     },
     "process-stats_18": {
       "inputs": {
-        "logos-nix": "logos-nix_766",
+        "logos-nix": "logos-nix_767",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -62705,7 +62762,7 @@
     },
     "process-stats_19": {
       "inputs": {
-        "logos-nix": "logos-nix_810",
+        "logos-nix": "logos-nix_811",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -62773,7 +62830,7 @@
     },
     "process-stats_20": {
       "inputs": {
-        "logos-nix": "logos-nix_838",
+        "logos-nix": "logos-nix_839",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -62804,7 +62861,7 @@
     },
     "process-stats_21": {
       "inputs": {
-        "logos-nix": "logos-nix_871",
+        "logos-nix": "logos-nix_872",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -62983,7 +63040,7 @@
     },
     "process-stats_8": {
       "inputs": {
-        "logos-nix": "logos-nix_336",
+        "logos-nix": "logos-nix_337",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -63016,7 +63073,7 @@
     },
     "process-stats_9": {
       "inputs": {
-        "logos-nix": "logos-nix_380",
+        "logos-nix": "logos-nix_381",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -63051,6 +63108,7 @@
     "root": {
       "inputs": {
         "logos-module-builder": "logos-module-builder",
+        "logos-package": "logos-package_36",
         "package_downloader": "package_downloader",
         "package_manager": "package_manager"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,12 @@
 
     package_manager.url = "github:logos-co/logos-package-manager-module";
     package_downloader.url = "github:logos-co/logos-package-downloader-module";
+
+    # Header-only: supplies the shared semver implementation
+    # (include/logos/semver.hpp), which RowActionResolver.h uses to decide
+    # Upgrade / Downgrade / Reinstall. We take the headers only — nothing here
+    # links liblgx, so this drags in no ICU/libsodium/zlib.
+    logos-package.url = "github:logos-co/logos-package";
   };
 
   outputs = inputs@{ logos-module-builder, ... }:
@@ -13,5 +19,26 @@
       src = ./.;
       configFile = ./metadata.json;
       flakeInputs = inputs;
+
+      externalLibInputs = {
+        lgx = {
+          input = inputs.logos-package;
+          packages.default = "lib";
+        };
+      };
+
+      # Stage the shared semver headers into the tree so CMake can see them.
+      #
+      # The builder's normal external-lib staging flattens `include/*.h` into a
+      # single `lib/` directory, which would both drop our `.hpp` files and
+      # collapse `logos/semver.hpp` and `semver/semver.hpp` onto the same name.
+      # Copy the directories across intact instead; CMakeLists puts `vendor/` on
+      # the include path. preConfigure gets the per-system resolved derivation.
+      preConfigure = { externalLibs }: ''
+        mkdir -p vendor
+        cp -r ${externalLibs.lgx}/include/logos vendor/
+        cp -r ${externalLibs.lgx}/include/semver vendor/
+        chmod -R u+w vendor
+      '';
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,11 @@
       # Copy the directories across intact instead; CMakeLists puts `vendor/` on
       # the include path. preConfigure gets the per-system resolved derivation.
       preConfigure = { externalLibs }: ''
+        # Clear any previously staged headers first, so an incremental/local
+        # build after the logos-package input changes can't leave a stale tree
+        # behind. (Nix sandbox builds start clean, but `nix develop` reuses the
+        # source dir.)
+        rm -rf vendor
         mkdir -p vendor
         cp -r ${externalLibs.lgx}/include/logos vendor/
         cp -r ${externalLibs.lgx}/include/semver vendor/

--- a/flake.nix
+++ b/flake.nix
@@ -20,10 +20,18 @@
       configFile = ./metadata.json;
       flakeInputs = inputs;
 
+      # `headers`, NOT `lib` — deliberately.
+      #
+      # The module builder copies every *.so/*.dylib an external library ships
+      # into the plugin's output lib/, and ui-host then scans that directory and
+      # tries to load each file as a Qt plugin. Pointing at logos-package's
+      # `lib` output put liblgx.dylib there, ui-host failed to load it as a
+      # plugin, and the whole UI never rendered. The `headers` output ships no
+      # library at all, so there is nothing to copy.
       externalLibInputs = {
         lgx = {
           input = inputs.logos-package;
-          packages.default = "lib";
+          packages.default = "headers";
         };
       };
 

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
       "build": [],
       "runtime": ["qt6.qtdeclarative", "zstd", "krb5", "abseil-cpp"]
     },
-    "external_libraries": [],
+    "external_libraries": [{ "name": "lgx" }],
     "cmake": { "find_packages": [], "extra_sources": [] }
   }
 }

--- a/src/RowActionResolver.h
+++ b/src/RowActionResolver.h
@@ -1,13 +1,12 @@
 #pragma once
 
-// Single source of truth for the dotted-numeric version compare AND for
-// the per-row Action resolution. The Action surfaced in the table's
-// Action column must reflect the row's CURRENTLY SELECTED dropdown
-// version, so this logic has to be reachable from two places: the
-// initial row build in PackageManagerBackend.cpp::buildPackageRow (sets
-// it against versions[0]) and PackageListModel::setRowVersion (recomputes
-// against the picked version). The previous arrangement kept versionCmp
-// file-local in PackageManagerBackend.cpp, which is exactly why
+// Single source of truth for the per-row Action resolution. The Action
+// surfaced in the table's Action column must reflect the row's CURRENTLY
+// SELECTED dropdown version, so this logic has to be reachable from two
+// places: the initial row build in PackageManagerBackend.cpp::buildPackageRow
+// (sets it against versions[0]) and PackageListModel::setRowVersion
+// (recomputes against the picked version). The previous arrangement kept
+// versionCmp file-local in PackageManagerBackend.cpp, which is exactly why
 // setRowVersion couldn't recompute — and exactly why the "Upgrade" badge
 // kept lying about installed/older picks.
 //
@@ -15,31 +14,25 @@
 // the model.
 
 #include <QString>
-#include <QStringList>
-#include <algorithm>
+
+#include <logos/semver.hpp>
 
 #include "PackageTypes.h"
 
 namespace rowaction {
 
-// Three-way dotted-numeric compare ("1.2.3" vs "1.2.10"). Missing
-// trailing components are treated as 0. Returns -1 / 0 / +1.
+// Three-way version compare. Returns -1 / 0 / +1.
 //
-// Same semantics as the previous file-local versionCmp in
-// PackageManagerBackend.cpp — moved here verbatim so both buildPackageRow
-// and setRowVersion can use it.
+// Delegates to the shared semver implementation in logos-package — the same
+// code lgx, lgpm and lgpd use. It used to split on '.' and QString::toInt()
+// each component (discarding the `ok` flag), so "0-rc1".toInt() silently
+// yielded 0 and every pre-release compared EQUAL to its own release:
+// `1.0.0-rc.1` and `1.0.0` looked identical, so an available upgrade from an
+// rc to the real release showed no Upgrade action at all. `1.0.0-rc.2` vs
+// `1.0.0-rc.10` compared equal too.
 inline int versionCmp(const QString& a, const QString& b)
 {
-    const QStringList aParts = a.split('.');
-    const QStringList bParts = b.split('.');
-    const int n = std::max(aParts.size(), bParts.size());
-    for (int i = 0; i < n; ++i) {
-        const int av = (i < aParts.size()) ? aParts[i].toInt() : 0;
-        const int bv = (i < bParts.size()) ? bParts[i].toInt() : 0;
-        if (av < bv) return -1;
-        if (av > bv) return  1;
-    }
-    return 0;
+    return logos::semver::compare(a.toStdString(), b.toStdString());
 }
 
 // Resolve the per-row primary action given (installed, selected,


### PR DESCRIPTION
Part of a 6-PR chain unifying semver handling. **Depends on logos-co/logos-package#30** (the shared implementation).

## The bug

`rowaction::versionCmp` split on `.` and `QString::toInt()`'d each component — **discarding the `ok` flag**:

```cpp
const int av = (i < aParts.size()) ? aParts[i].toInt() : 0;   // "0-rc1".toInt() -> 0
```

`"0-rc1".toInt()` silently yields `0`, so every pre-release compared **equal to its own release**. Consequences, all user-visible:

- an installed `1.0.0-rc.1` against an available `1.0.0` showed **no Upgrade action at all** — they looked like the same version;
- `1.0.0-rc.2` vs `1.0.0-rc.10` compared equal;
- `1.0.0+build1` and `1.0.0` compared equal (harmless, but by accident).

This comparator drives **every** Upgrade / Downgrade / Reinstall decision in the table — the row build, the per-row Action pill, the update-available marker, and the dependency-change preview — and it had **no unit coverage**, because there is no C++ test target in this repo.

## The fix

It now forwards to the shared implementation in logos-package (`include/logos/semver.hpp`) — the same code lgx, lgpm and lgpd use. The comparator logic leaves this repo entirely, so the coverage gap closes by *centralisation* rather than by bolting a C++ test target onto a QML module. Exhaustive spec coverage lives in logos-package's `test_semver.cpp`.

## Headers only — no new runtime weight

This is the one repo in the chain that needed a new dependency edge: it's a QML plugin with no native link deps today. It takes **headers only** — nothing here links `liblgx`, so no zlib / ICU / libsodium enters the plugin. Verified:

```
$ otool -L result/lib/package_manager_ui_plugin.dylib | grep -iE 'lgx|icu|sodium'
(no output)
```

Getting there needed one non-obvious step. module-builder's external-lib staging flattens `include/*.h` into a single directory — which would drop our `.hpp` files entirely and collide `logos/semver.hpp` with `semver/semver.hpp`. And `EXTERNAL_LIBS` forces a `find_library` + link, which would drag `liblgx` (and ICU/libsodium/zlib) in. So instead:

- `externalLibInputs` resolves logos-package's `lib` output per-system;
- the flake's `preConfigure` — declared as a **function of `{ externalLibs }`**, which is how it receives that resolved derivation — copies the header directories across intact into `vendor/`;
- `CMakeLists.txt` puts `vendor/` on the include path via `INCLUDE_DIRS`.

No link step, no closure growth.

## Chain

`flake.lock` pins the new `logos-package` input at #30's branch head so CI can build; **re-pin to `master` once #30 merges**. Verified green against that pin.

Merge order: logos-package#30 → logos-package-manager#25 / logos-package-downloader#17 → **this** → modules-release-tool → workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)