### PR TITLE
fix: always confirm installs; pass the installed set to the download path

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62408,11 +62408,11 @@
         "logos-package-downloader": "logos-package-downloader"
       },
       "locked": {
-        "lastModified": 1784226902,
+        "lastModified": 1784227209,
         "narHash": "sha256-BK6oygfnpxFxWJr2AGJ9ldIDwAg4rvwFdFAyEOziTMY=",
         "owner": "logos-co",
         "repo": "logos-package-downloader-module",
-        "rev": "c06e223536f3fb9c6e619f5bd75cfac6c77ad41f",
+        "rev": "6b8790ecebb56091c088da69b6a0faa18dcb2ce1",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -62408,11 +62408,11 @@
         "logos-package-downloader": "logos-package-downloader"
       },
       "locked": {
-        "lastModified": 1784209035,
-        "narHash": "sha256-rc3SHfjZDOAyFhr1ILXQtUoGP4ffKsURBFhSDJOq6Z4=",
+        "lastModified": 1784219443,
+        "narHash": "sha256-QZxsYmMinnaVuxQAb1Ee9NjWCw4iI/lrEB8g0C3rCQY=",
         "owner": "logos-co",
         "repo": "logos-package-downloader-module",
-        "rev": "02fcb4abd85fe2eef26094dd3cb46ed5585867c8",
+        "rev": "bb05a5f252cf7a4e43008d6831d01da25315e2a3",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -28021,11 +28021,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784207645,
-        "narHash": "sha256-FEq/vi4ejVFmltUFl6SuP7WwKgy7JgZULekYcUWmUKE=",
+        "lastModified": 1784226863,
+        "narHash": "sha256-4B+UmgnZTIY3tvXSHtFAVaiGzHYm7Lmo/LaYrt4BinM=",
         "owner": "logos-co",
         "repo": "logos-package-downloader",
-        "rev": "736f8ebcf06f754a58e80bde0a51645070418573",
+        "rev": "8d5128b2195bb8bdebb3f623fa2026b0546203dc",
         "type": "github"
       },
       "original": {
@@ -62408,11 +62408,11 @@
         "logos-package-downloader": "logos-package-downloader"
       },
       "locked": {
-        "lastModified": 1784219443,
-        "narHash": "sha256-QZxsYmMinnaVuxQAb1Ee9NjWCw4iI/lrEB8g0C3rCQY=",
+        "lastModified": 1784226902,
+        "narHash": "sha256-BK6oygfnpxFxWJr2AGJ9ldIDwAg4rvwFdFAyEOziTMY=",
         "owner": "logos-co",
         "repo": "logos-package-downloader-module",
-        "rev": "bb05a5f252cf7a4e43008d6831d01da25315e2a3",
+        "rev": "c06e223536f3fb9c6e619f5bd75cfac6c77ad41f",
         "type": "github"
       },
       "original": {

--- a/src/PackageManagerBackend.cpp
+++ b/src/PackageManagerBackend.cpp
@@ -985,7 +985,7 @@ void PackageManagerBackend::installSinglePackageAsync(const QString& packageName
     const QString depsJson = buildDepsJson({spec});
     LogosModules logos(m_logosAPI);
     QPointer<PackageManagerBackend> self(this);
-    logos.package_downloader.downloadResolvedDependenciesAsync(depsJson,
+    logos.package_downloader.downloadResolvedDependenciesAsync(depsJson, buildInstalledPackagesJson(),
         [self, packageName, includeDeps](QVariantList results) {
             if (!self) return;
             // Filter to top-level entries when the caller asked for
@@ -1152,7 +1152,7 @@ void PackageManagerBackend::installSpecs(const QList<PackageInstallSpec>& specs,
 
     LogosModules logos(m_logosAPI);
     QPointer<PackageManagerBackend> self(this);
-    logos.package_downloader.downloadResolvedDependenciesAsync(depsJson,
+    logos.package_downloader.downloadResolvedDependenciesAsync(depsJson, buildInstalledPackagesJson(),
         [self, includeDeps](QVariantList results) {
             if (!self) return;
             if (!includeDeps) {
@@ -1301,16 +1301,11 @@ void PackageManagerBackend::runDepPreviewForAction(const QString& packageName,
             if (!self) return;
             const QVariantList changes = self->computeDepChanges(
                 resolved, installedByName, repoUrlToName);
-            if (changes.isEmpty()) {
-                // No transitive changes needed — proceed silently with
-                // the full path (includeDeps=true; resolver returns
-                // only top-level so the install is unchanged in scope
-                // from "no preview" behaviour).
-                self->dispatchPendingAction(packageName, moduleName, repoUrl,
-                                            version, actionKind,
-                                            /*includeDeps=*/true);
-                return;
-            }
+            // Always confirm — even a plain single-package install with no
+            // transitive changes surfaces a confirmation (the dialog renders a
+            // simple "Install <pkg> <version>?" when `changes` is empty). This
+            // is deliberate: an install must never happen silently. When there
+            // ARE changes the same dialog lists them.
             // Stash + ask the user. The dialog dispatches back via
             // confirmInstallWith{,out}Deps / cancelInstallConfirm, keyed
             // by an opaque requestKey. The key is repo-scoped so two
@@ -1715,7 +1710,7 @@ void PackageManagerBackend::onUpgradeUninstallDone(const QString& moduleName,
 
     LogosModules logos(m_logosAPI);
     QPointer<PackageManagerBackend> self(this);
-    logos.package_downloader.downloadResolvedDependenciesAsync(depsJson,
+    logos.package_downloader.downloadResolvedDependenciesAsync(depsJson, buildInstalledPackagesJson(),
         [self, displayName, mode, includeDeps = meta.includeDeps]
         (QVariantList results) {
             if (!self) return;

--- a/src/qml/Panels/InstallDepsConfirm.qml
+++ b/src/qml/Panels/InstallDepsConfirm.qml
@@ -253,10 +253,11 @@ Popup {
                 Layout.fillWidth: true
                 Layout.preferredHeight: 38
                 radius: Theme.spacing.radiusLarge
-                // With no dep changes, the with/without-deps split is
-                // meaningless — a single plain "<action>" confirms the install.
+                // Verb tracks actionLabel (Install / Upgrade / Downgrade /
+                // Reinstall). With no dep changes the with/without-deps split is
+                // meaningless — a single plain "<action>" confirms it.
                 text: (root.depChanges || []).length > 0
-                      ? qsTr("Install with dependencies")
+                      ? qsTr("%1 with dependencies").arg(root.actionLabel)
                       : root.actionLabel
                 onClicked: {
                     root._explicitClose = true
@@ -270,7 +271,7 @@ Popup {
                 radius: Theme.spacing.radiusLarge
                 // Redundant when there are no transitive changes.
                 visible: (root.depChanges || []).length > 0
-                text: qsTr("Install just '%1'").arg(root.displayName)
+                text: qsTr("%1 just '%2'").arg(root.actionLabel).arg(root.displayName)
                 onClicked: {
                     root._explicitClose = true
                     root.confirmedWithoutDeps(root.requestKey)

--- a/src/qml/Panels/InstallDepsConfirm.qml
+++ b/src/qml/Panels/InstallDepsConfirm.qml
@@ -120,6 +120,10 @@ Popup {
         // translatable as a whole rather than concatenated fragments.
         function bodyText() {
             var n = (root.depChanges || []).length
+            if (n === 0)
+                // Plain single-package confirm — no transitive changes. The
+                // title already names the package + version being installed.
+                return qsTr("No other packages need to change.")
             return n === 1
                 ? qsTr("This %1 requires changes to 1 dependency that isn't already on disk in a compatible version.")
                       .arg(root.actionLabel.toLowerCase())
@@ -249,7 +253,11 @@ Popup {
                 Layout.fillWidth: true
                 Layout.preferredHeight: 38
                 radius: Theme.spacing.radiusLarge
-                text: qsTr("Install with dependencies")
+                // With no dep changes, the with/without-deps split is
+                // meaningless — a single plain "<action>" confirms the install.
+                text: (root.depChanges || []).length > 0
+                      ? qsTr("Install with dependencies")
+                      : root.actionLabel
                 onClicked: {
                     root._explicitClose = true
                     root.confirmedWithDeps(root.requestKey)
@@ -260,6 +268,8 @@ Popup {
                 Layout.fillWidth: true
                 Layout.preferredHeight: 38
                 radius: Theme.spacing.radiusLarge
+                // Redundant when there are no transitive changes.
+                visible: (root.depChanges || []).length > 0
                 text: qsTr("Install just '%1'").arg(root.displayName)
                 onClicked: {
                     root._explicitClose = true


### PR DESCRIPTION
Fixes both parts of reported issue 1. **Depends on logos-co/logos-package-downloader-module#17** (2-arg download signature, re-pinned here).

## Issue 1a — no dialog for simple installs

The confirmation dialog was gated on `if (changes.isEmpty())`: when the resolver reported no transitive changes, the install ran **silently**. Now a confirmation is shown for **every** install. `InstallDepsConfirm` renders a plain "Install '<pkg>' v<ver>?" with an *Install* / *Cancel* choice when there are no dep changes, and lists the changes when there are (the existing three-way "with deps" / "just this" / "cancel").

## Issue 1b — the download silently upgraded a satisfied installed dep

The three `downloadResolvedDependenciesAsync` calls passed only the deps JSON, so the download re-resolved installed-blind and upgraded a dep the preview said would stay put. They now pass `buildInstalledPackagesJson()` — the same installed set the preview gets — so download matches preview.

Re-pins the `package_downloader` module for the 2-arg download signature.

Part of a 4-PR set. Merge order: downloader#18 → downloader-module#17 → **this** / basecamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)