### PR TITLE
feat: route install/upgrade confirmation through the host gate

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62408,11 +62408,11 @@
         "logos-package-downloader": "logos-package-downloader"
       },
       "locked": {
-        "lastModified": 1784226902,
+        "lastModified": 1784227209,
         "narHash": "sha256-BK6oygfnpxFxWJr2AGJ9ldIDwAg4rvwFdFAyEOziTMY=",
         "owner": "logos-co",
         "repo": "logos-package-downloader-module",
-        "rev": "c06e223536f3fb9c6e619f5bd75cfac6c77ad41f",
+        "rev": "6b8790ecebb56091c088da69b6a0faa18dcb2ce1",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -62427,11 +62427,11 @@
         "logos-package-manager": "logos-package-manager_43"
       },
       "locked": {
-        "lastModified": 1784208334,
-        "narHash": "sha256-3aA1n6M1P41nMgeZmZ/s72WOY87FrxFSOIGJ4c4NfM8=",
+        "lastModified": 1784232744,
+        "narHash": "sha256-f6txL+Wnlxx5eTdu5klr8qtzvPy49dFtNo30qd74PtQ=",
         "owner": "logos-co",
         "repo": "logos-package-manager-module",
-        "rev": "439b580b115718a3b2e1637f2816b8ea6ea7decc",
+        "rev": "411ea1135780741acd243564c33840bc838729f7",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -62408,11 +62408,11 @@
         "logos-package-downloader": "logos-package-downloader"
       },
       "locked": {
-        "lastModified": 1784209035,
-        "narHash": "sha256-rc3SHfjZDOAyFhr1ILXQtUoGP4ffKsURBFhSDJOq6Z4=",
+        "lastModified": 1784219443,
+        "narHash": "sha256-QZxsYmMinnaVuxQAb1Ee9NjWCw4iI/lrEB8g0C3rCQY=",
         "owner": "logos-co",
         "repo": "logos-package-downloader-module",
-        "rev": "02fcb4abd85fe2eef26094dd3cb46ed5585867c8",
+        "rev": "bb05a5f252cf7a4e43008d6831d01da25315e2a3",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -62427,11 +62427,11 @@
         "logos-package-manager": "logos-package-manager_43"
       },
       "locked": {
-        "lastModified": 1784232744,
-        "narHash": "sha256-f6txL+Wnlxx5eTdu5klr8qtzvPy49dFtNo30qd74PtQ=",
+        "lastModified": 1784254343,
+        "narHash": "sha256-3+JOesTqQsSy2y0EYphzQXSL5c4TDnzT4lzPF32xO0E=",
         "owner": "logos-co",
         "repo": "logos-package-manager-module",
-        "rev": "411ea1135780741acd243564c33840bc838729f7",
+        "rev": "cad6bab044d09eb54fe9a8efb20ed94694eb44ff",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -28021,11 +28021,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784207645,
-        "narHash": "sha256-FEq/vi4ejVFmltUFl6SuP7WwKgy7JgZULekYcUWmUKE=",
+        "lastModified": 1784226863,
+        "narHash": "sha256-4B+UmgnZTIY3tvXSHtFAVaiGzHYm7Lmo/LaYrt4BinM=",
         "owner": "logos-co",
         "repo": "logos-package-downloader",
-        "rev": "736f8ebcf06f754a58e80bde0a51645070418573",
+        "rev": "8d5128b2195bb8bdebb3f623fa2026b0546203dc",
         "type": "github"
       },
       "original": {
@@ -62408,11 +62408,11 @@
         "logos-package-downloader": "logos-package-downloader"
       },
       "locked": {
-        "lastModified": 1784219443,
-        "narHash": "sha256-QZxsYmMinnaVuxQAb1Ee9NjWCw4iI/lrEB8g0C3rCQY=",
+        "lastModified": 1784226902,
+        "narHash": "sha256-BK6oygfnpxFxWJr2AGJ9ldIDwAg4rvwFdFAyEOziTMY=",
         "owner": "logos-co",
         "repo": "logos-package-downloader-module",
-        "rev": "bb05a5f252cf7a4e43008d6831d01da25315e2a3",
+        "rev": "c06e223536f3fb9c6e619f5bd75cfac6c77ad41f",
         "type": "github"
       },
       "original": {

--- a/src/PackageManagerBackend.cpp
+++ b/src/PackageManagerBackend.cpp
@@ -985,7 +985,7 @@ void PackageManagerBackend::installSinglePackageAsync(const QString& packageName
     const QString depsJson = buildDepsJson({spec});
     LogosModules logos(m_logosAPI);
     QPointer<PackageManagerBackend> self(this);
-    logos.package_downloader.downloadResolvedDependenciesAsync(depsJson,
+    logos.package_downloader.downloadResolvedDependenciesAsync(depsJson, buildInstalledPackagesJson(),
         [self, packageName, includeDeps](QVariantList results) {
             if (!self) return;
             // Filter to top-level entries when the caller asked for
@@ -1152,7 +1152,7 @@ void PackageManagerBackend::installSpecs(const QList<PackageInstallSpec>& specs,
 
     LogosModules logos(m_logosAPI);
     QPointer<PackageManagerBackend> self(this);
-    logos.package_downloader.downloadResolvedDependenciesAsync(depsJson,
+    logos.package_downloader.downloadResolvedDependenciesAsync(depsJson, buildInstalledPackagesJson(),
         [self, includeDeps](QVariantList results) {
             if (!self) return;
             if (!includeDeps) {
@@ -1301,16 +1301,11 @@ void PackageManagerBackend::runDepPreviewForAction(const QString& packageName,
             if (!self) return;
             const QVariantList changes = self->computeDepChanges(
                 resolved, installedByName, repoUrlToName);
-            if (changes.isEmpty()) {
-                // No transitive changes needed — proceed silently with
-                // the full path (includeDeps=true; resolver returns
-                // only top-level so the install is unchanged in scope
-                // from "no preview" behaviour).
-                self->dispatchPendingAction(packageName, moduleName, repoUrl,
-                                            version, actionKind,
-                                            /*includeDeps=*/true);
-                return;
-            }
+            // Always confirm — even a plain single-package install with no
+            // transitive changes surfaces a confirmation (the dialog renders a
+            // simple "Install <pkg> <version>?" when `changes` is empty). This
+            // is deliberate: an install must never happen silently. When there
+            // ARE changes the same dialog lists them.
             // Stash + ask the user. The dialog dispatches back via
             // confirmInstallWith{,out}Deps / cancelInstallConfirm, keyed
             // by an opaque requestKey. The key is repo-scoped so two
@@ -1715,7 +1710,7 @@ void PackageManagerBackend::onUpgradeUninstallDone(const QString& moduleName,
 
     LogosModules logos(m_logosAPI);
     QPointer<PackageManagerBackend> self(this);
-    logos.package_downloader.downloadResolvedDependenciesAsync(depsJson,
+    logos.package_downloader.downloadResolvedDependenciesAsync(depsJson, buildInstalledPackagesJson(),
         [self, displayName, mode, includeDeps = meta.includeDeps]
         (QVariantList results) {
             if (!self) return;

--- a/src/PackageManagerBackend.cpp
+++ b/src/PackageManagerBackend.cpp
@@ -1283,46 +1283,30 @@ void PackageManagerBackend::runDepPreviewForAction(const QString& packageName,
         const QString ver = m.value("version").toString();
         if (!n.isEmpty() && !ver.isEmpty()) installedByName.insert(n, ver);
     }
-    // displayName + fromVersion + action label for the signal payload.
-    const QString displayName = moduleName.isEmpty() ? packageName : moduleName;
-    const QString fromVersion = installedByName.value(displayName);
-    static const char* kActionLabels[] = {"Install", "Upgrade", "Downgrade", "Reinstall"};
-    const QString actionLabel = (actionKind >= 0 && actionKind <= 3)
-                                ? QString::fromLatin1(kActionLabels[actionKind])
-                                : QStringLiteral("Install");
-
     LogosModules logos(m_logosAPI);
     QPointer<PackageManagerBackend> self(this);
     logos.package_downloader.resolveDependenciesAsync(depsJson, installedJson,
         [self, packageName, moduleName, repoUrl, version, actionKind,
-         displayName, fromVersion, actionLabel,
          installedByName, repoUrlToName]
         (QVariantList resolved) {
             if (!self) return;
             const QVariantList changes = self->computeDepChanges(
                 resolved, installedByName, repoUrlToName);
-            // Always confirm — even a plain single-package install with no
-            // transitive changes surfaces a confirmation (the dialog renders a
-            // simple "Install <pkg> <version>?" when `changes` is empty). This
-            // is deliberate: an install must never happen silently. When there
-            // ARE changes the same dialog lists them.
-            // Stash + ask the user. The dialog dispatches back via
-            // confirmInstallWith{,out}Deps / cancelInstallConfirm, keyed
-            // by an opaque requestKey. The key is repo-scoped so two
-            // rows sharing a package name across repos don't collide:
-            // `<repositoryUrl>\n<name>`. ('\n' can't appear in a URL or
-            // a package name, so it's an unambiguous separator.)
-            PendingDepConfirm p;
-            p.name          = packageName;
-            p.moduleName    = moduleName;
-            p.repositoryUrl = repoUrl;
-            p.version       = version;
-            p.action        = actionKind;
-            const QString requestKey = repoUrl + QLatin1Char('\n') + packageName;
-            self->m_pendingDepConfirms.insert(requestKey, p);
-            emit self->installDepsConfirmationRequested(
-                requestKey, packageName, displayName, actionLabel,
-                fromVersion, version, changes);
+            // Route the confirmation to the HOST (basecamp) instead of showing
+            // PMU's own dialog: serialise the resolved change list and hand it
+            // to the package_manager gate (requestInstall / requestUpgrade).
+            // basecamp subscribes to beforeInstall / beforeUpgrade and shows
+            // ONE dialog — titled for the action and listing these `changes` —
+            // so the user no longer sees a PMU dialog followed by a basecamp
+            // one. An install must still never happen silently, but that
+            // confirmation now lives entirely in the host. The old in-PMU
+            // InstallDepsConfirm path (installDepsConfirmationRequested +
+            // confirmInstallWith{,out}Deps) is retired and never emitted.
+            const QString changesJson = QString::fromUtf8(
+                QJsonDocument(QJsonArray::fromVariantList(changes))
+                    .toJson(QJsonDocument::Compact));
+            self->dispatchPendingAction(packageName, moduleName, repoUrl,
+                                        version, actionKind, changesJson);
         });
 }
 
@@ -1331,17 +1315,27 @@ void PackageManagerBackend::dispatchPendingAction(const QString& packageName,
                                                   const QString& repoUrl,
                                                   const QString& version,
                                                   int actionKind,
-                                                  bool includeDeps)
+                                                  const QString& depChangesJson)
 {
-    // Central dispatch for resolver-confirm responses (and the silent
-    // "no transitive changes" path). Each branch matches the per-row
-    // entry-point it'd otherwise have run, just with the includeDeps
-    // flag plumbed through. The upgrade family stashes
-    // PendingUpgradeMeta so onUpgradeUninstallDone picks up the
-    // includeDeps choice at the post-uninstall download step.
+    // Central dispatch: route the action through the package_manager gate so
+    // the HOST (basecamp) owns the confirmation dialog. `depChangesJson` is the
+    // resolved transitive change list, echoed into the module's beforeInstall /
+    // beforeUpgrade event so the host dialog can list it. On approval the module
+    // emits installApproved / upgradeUninstallDone; PMU then runs the actual
+    // download+install (onInstallApproved / onUpgradeUninstallDone). Deps are
+    // always included now — the host dialog is confirm-or-cancel, with no
+    // "just the package" split — so PendingUpgradeMeta.includeDeps stays true.
+    LogosModules logos(m_logosAPI);
+    QPointer<PackageManagerBackend> self(this);
     switch (static_cast<PendingDepConfirm::Action>(actionKind)) {
     case PendingDepConfirm::Install:
-        installSinglePackageAsync(packageName, repoUrl, version, includeDeps);
+        logos.package_manager.requestInstallAsync(packageName, version, repoUrl, depChangesJson,
+            [self](QVariantMap result) {
+                if (!self) return;
+                if (!result.value("success", false).toBool())
+                    emit self->errorOccurred(
+                        static_cast<int>(PackageTypes::InstallationAlreadyInProgress));
+            });
         return;
     case PendingDepConfirm::Upgrade:
     case PendingDepConfirm::Downgrade:
@@ -1349,14 +1343,12 @@ void PackageManagerBackend::dispatchPendingAction(const QString& packageName,
         if (!moduleName.isEmpty()) {
             PendingUpgradeMeta meta;
             meta.repositoryUrl = repoUrl;
-            meta.includeDeps   = includeDeps;
+            meta.includeDeps   = true;
             m_pendingUpgradeByModule.insert(moduleName, meta);
         }
         const int mode = (actionKind == PendingDepConfirm::Downgrade) ? 1
                        : (actionKind == PendingDepConfirm::Sidegrade) ? 2 : 0;
-        LogosModules logos(m_logosAPI);
-        QPointer<PackageManagerBackend> self(this);
-        logos.package_manager.requestUpgradeAsync(moduleName, version, mode,
+        logos.package_manager.requestUpgradeAsync(moduleName, version, mode, depChangesJson,
             [self](QVariantMap result) {
                 if (!self) return;
                 if (!result.value("success", false).toBool())
@@ -1368,20 +1360,20 @@ void PackageManagerBackend::dispatchPendingAction(const QString& packageName,
     }
 }
 
+// Retired: the in-PMU dep-confirm dialog is superseded by the host gate — the
+// confirmation now lives in basecamp (see runDepPreviewForAction, which routes
+// straight to the package_manager gate). These .rep slots remain so the
+// generated interface stays satisfied, but the signal that drove them
+// (installDepsConfirmationRequested) is no longer emitted, so they never run.
+// Drain any stale pending entry defensively and do nothing else.
 void PackageManagerBackend::confirmInstallWithDeps(QString requestKey)
 {
-    if (!m_pendingDepConfirms.contains(requestKey)) return;
-    const PendingDepConfirm p = m_pendingDepConfirms.take(requestKey);
-    dispatchPendingAction(p.name, p.moduleName, p.repositoryUrl, p.version,
-                          p.action, /*includeDeps=*/true);
+    m_pendingDepConfirms.remove(requestKey);
 }
 
 void PackageManagerBackend::confirmInstallWithoutDeps(QString requestKey)
 {
-    if (!m_pendingDepConfirms.contains(requestKey)) return;
-    const PendingDepConfirm p = m_pendingDepConfirms.take(requestKey);
-    dispatchPendingAction(p.name, p.moduleName, p.repositoryUrl, p.version,
-                          p.action, /*includeDeps=*/false);
+    m_pendingDepConfirms.remove(requestKey);
 }
 
 void PackageManagerBackend::cancelInstallConfirm(QString requestKey)
@@ -1582,6 +1574,15 @@ void PackageManagerBackend::subscribePackageManagerCancellationEvents()
                             obj.value("releaseTag").toString(),
                             reason);
         });
+
+    // Fresh-install gate cancellation (host declined, or the ack timed out with
+    // no host listening). "user cancelled" is filtered by the helper — no toast
+    // when the user themselves clicked Cancel.
+    subscribe("installCancelled",
+        [](const QJsonObject& obj, const QString& reason) {
+            return QStringLiteral("Install of '%1' cancelled: %2")
+                       .arg(obj.value("name").toString(), reason);
+        });
 }
 
 void PackageManagerBackend::subscribePackageManagerRefreshEvents()
@@ -1644,6 +1645,30 @@ void PackageManagerBackend::subscribePackageManagerUpgradeEvents()
                                          obj.value("releaseTag").toString(),
                                          obj.value("mode").toInt());
         });
+
+    // installApproved fires after the host confirms a fresh catalog install
+    // through the gate. Payload: { name, releaseTag, repositoryUrl }. PMU runs
+    // the actual download+install — the sibling of onUpgradeUninstallDone for
+    // the no-old-version-to-remove case.
+    logos.package_manager.on("installApproved",
+        [self](const QVariantList& data) {
+            if (!self) return;
+            const QJsonObject obj = parseEventPayload(data);
+            if (obj.isEmpty()) return;
+            self->onInstallApproved(obj.value("name").toString(),
+                                    obj.value("releaseTag").toString(),
+                                    obj.value("repositoryUrl").toString());
+        });
+}
+
+void PackageManagerBackend::onInstallApproved(const QString& name,
+                                              const QString& releaseTag,
+                                              const QString& repositoryUrl)
+{
+    // Host approved the gated install — run the real download+install. The
+    // gate's whole job was the confirmation; deps are always included (the
+    // host dialog is confirm-or-cancel, no "just the package" split).
+    installSinglePackageAsync(name, repositoryUrl, releaseTag, /*includeDeps=*/true);
 }
 
 void PackageManagerBackend::onUpgradeUninstallDone(const QString& moduleName,

--- a/src/PackageManagerBackend.h
+++ b/src/PackageManagerBackend.h
@@ -154,17 +154,20 @@ private:
                                 const QString& version,
                                 int actionKind);
 
-    // Run the actual install / upgrade / downgrade / sidegrade for the
-    // (packageName, repo, version) the user picked. Called from
-    // runDepPreviewForAction (no-changes path) and from
-    // confirmInstallWith{,out}Deps (post-dialog). includeDeps controls
-    // whether transitive resolver picks are installed or filtered out.
+    // Route the install / upgrade / downgrade / sidegrade the user picked
+    // through the package_manager gate (requestInstall / requestUpgrade) so
+    // the host (basecamp) owns the confirmation dialog. `depChangesJson` is the
+    // resolved transitive change list, forwarded verbatim into the gate so the
+    // host dialog can list it. Called from runDepPreviewForAction once the
+    // resolver returns. The module's installApproved / upgradeUninstallDone
+    // event then drives the actual download+install (onInstallApproved /
+    // onUpgradeUninstallDone).
     void dispatchPendingAction(const QString& packageName,
                                const QString& moduleName,
                                const QString& repoUrl,
                                const QString& version,
                                int actionKind,
-                               bool includeDeps);
+                               const QString& depChangesJson);
 
     // Compute the user-facing change list. Walks `resolved` (output of
     // package_downloader.resolveDependencies) for transitive (topLevel
@@ -234,6 +237,13 @@ private:
     void onUpgradeUninstallDone(const QString& moduleName,
                                 const QString& releaseTag,
                                 int mode);
+
+    // Handler for installApproved — the fresh-install sibling of
+    // onUpgradeUninstallDone. The host confirmed the gated catalog install;
+    // PMU runs the download+install for (name, version=releaseTag, repo).
+    void onInstallApproved(const QString& name,
+                           const QString& releaseTag,
+                           const QString& repositoryUrl);
 
     // onDone invoked with (success, errorMsg) regardless of outcome.
     void installOnePackage(const QVariantMap& dl,

--- a/src/qml/Panels/InstallDepsConfirm.qml
+++ b/src/qml/Panels/InstallDepsConfirm.qml
@@ -253,10 +253,11 @@ Popup {
                 Layout.fillWidth: true
                 Layout.preferredHeight: 38
                 radius: Theme.spacing.radiusLarge
-                // With no dep changes, the with/without-deps split is
-                // meaningless — a single plain "<action>" confirms the install.
+                // Verb tracks actionLabel (Install / Upgrade / Downgrade /
+                // Reinstall). With no dep changes the with/without-deps split is
+                // meaningless — a single plain "<action>" confirms it.
                 text: (root.depChanges || []).length > 0
-                      ? qsTr("Install with dependencies")
+                      ? qsTr("%1 with dependencies").arg(root.actionLabel)
                       : root.actionLabel
                 onClicked: {
                     root._explicitClose = true
@@ -270,7 +271,7 @@ Popup {
                 radius: Theme.spacing.radiusLarge
                 // Redundant when there are no transitive changes.
                 visible: (root.depChanges || []).length > 0
-                text: qsTr("Install just '%1'").arg(root.displayName)
+                text: qsTr("%1 just '%2'").arg(root.actionLabel).arg(root.displayName)
                 onClicked: {
                     root._explicitClose = true
                     root.confirmedWithoutDeps(root.requestKey)

--- a/src/qml/Panels/InstallDepsConfirm.qml
+++ b/src/qml/Panels/InstallDepsConfirm.qml
@@ -120,6 +120,10 @@ Popup {
         // translatable as a whole rather than concatenated fragments.
         function bodyText() {
             var n = (root.depChanges || []).length
+            if (n === 0)
+                // Plain single-package confirm — no transitive changes. The
+                // title already names the package + version being installed.
+                return qsTr("No other packages need to change.")
             return n === 1
                 ? qsTr("This %1 requires changes to 1 dependency that isn't already on disk in a compatible version.")
                       .arg(root.actionLabel.toLowerCase())
@@ -249,7 +253,11 @@ Popup {
                 Layout.fillWidth: true
                 Layout.preferredHeight: 38
                 radius: Theme.spacing.radiusLarge
-                text: qsTr("Install with dependencies")
+                // With no dep changes, the with/without-deps split is
+                // meaningless — a single plain "<action>" confirms the install.
+                text: (root.depChanges || []).length > 0
+                      ? qsTr("Install with dependencies")
+                      : root.actionLabel
                 onClicked: {
                     root._explicitClose = true
                     root.confirmedWithDeps(root.requestKey)
@@ -260,6 +268,8 @@ Popup {
                 Layout.fillWidth: true
                 Layout.preferredHeight: 38
                 radius: Theme.spacing.radiusLarge
+                // Redundant when there are no transitive changes.
+                visible: (root.depChanges || []).length > 0
                 text: qsTr("Install just '%1'").arg(root.displayName)
                 onClicked: {
                     root._explicitClose = true


### PR DESCRIPTION
## What

package_manager_ui no longer shows its own `InstallDepsConfirm` dialog. It resolves the transitive changes and hands them to the `package_manager` gate, so the **host (basecamp) shows a single confirmation dialog** that lists exactly what will change. This removes the double-dialog on upgrade/downgrade (PMU's dialog followed by basecamp's) and unifies install under the same host dialog.

- `runDepPreviewForAction` serialises `computeDepChanges` to JSON and calls `dispatchPendingAction`, which routes **Install -> `requestInstall`** and the **upgrade family -> `requestUpgrade`** (both carrying `depChangesJson`).
- On approval the module emits `installApproved` / `upgradeUninstallDone`; PMU runs the actual download+install (new `onInstallApproved` handler mirrors `onUpgradeUninstallDone`).
- Subscribes `installApproved` / `installCancelled`.
- The old in-PMU path (`installDepsConfirmationRequested` + `confirmInstallWith{,out}Deps`) is retired.

## Depends on

**logos-package-manager-module#57** (the `requestInstall` gate + `requestUpgrade` `depChanges` arg). Merge #57 first, then re-pin here.

Validated: builds against the local module gate; full `logos-basecamp` integration build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)