### PR TITLE
Sort catalog versions by SemVer, not release date, when picking the default (fixes #54)

### DIFF
--- a/src/PackageManagerBackend.cpp
+++ b/src/PackageManagerBackend.cpp
@@ -262,7 +262,20 @@ static QVariantMap buildPackageRow(const QVariantMap& obj,
     QVariantMap pkg;
     const QString name = obj.value("name").toString();
 
-    const QVariantList rawVersions = obj.value("versions").toList();
+    // Order versions by SemVer (highest first), not by the catalog's newest-by-`releasedAt`
+    // order. Otherwise a build published later but with a LOWER semver — e.g. a devnet
+    // sentinel `0.0.999` released after `0.2.0` — sorts to `versions[0]` and becomes the
+    // default selection, silently installing the wrong/devnet build
+    // (logos-co/logos-package-manager-ui#54). This also fixes the dropdown order and the
+    // `selectedVersionIndex = 0` default below, since both derive from `rawVersions`.
+    // Uses the shared `versionCmp` (logos::semver::compare); SemVer is now enforced upstream.
+    QVariantList rawVersions = obj.value("versions").toList();
+    std::sort(rawVersions.begin(), rawVersions.end(),
+              [](const QVariant& a, const QVariant& b) {
+                  const QString va = a.toMap().value("manifest").toMap().value("version").toString();
+                  const QString vb = b.toMap().value("manifest").toMap().value("version").toString();
+                  return versionCmp(va, vb) > 0; // descending: highest semver first
+              });
     QVariantMap selectedVersion;
     if (!rawVersions.isEmpty()) selectedVersion = rawVersions.first().toMap();
 


### PR DESCRIPTION
## Problem (fixes #54)

`buildPackageRow` picks **`versions[0]`** as the default selected version, and the catalog delivers `versions[]` **sorted newest-by-`releasedAt`**. So a build published *later* but with a **lower semver** — the devnet sentinel **`0.0.999`**, released after `0.2.0` — sorts to `versions[0]` and becomes the default. Accepting the default silently installs the **devnet** build, which starts, reports success, and never syncs testnet. @jzaki and others confirmed this ("blockchain_module was downgraded to 0.0.999").

## Fix

Sort `rawVersions` by **SemVer descending** before `.first()`, reusing the shared `versionCmp` (→ `logos::semver::compare`, already included via `RowActionResolver.h`). The dropdown model (`availableVersions`) and the `selectedVersionIndex = 0` default both derive from `rawVersions`, so this fixes the default selection **and** the dropdown order in one place. SemVer is enforced upstream now, so the comparison is unambiguous. Two edits, no new deps.

## Verified

Compiles + packages clean via `nix build '.#default'` (`PackageManagerBackend.cpp.o` built, module `.lgx` produced). **Runtime note:** I couldn't install the built plugin into a running Basecamp with a catalog carrying both versions, so the *visual* dropdown-order is un-verified at runtime — a reviewer with a Basecamp build can confirm quickly.

## Scope

- ✅ Fixes the **Package Manager dropdown default**.
- ⚠️ The **Applications route** (#54's second manifestation) and the **`blockchain_ui` dependency modal** (#56) look like separate code paths — not addressed here.
- 💡 The deepest fix is the **catalog sorting `versions[]` by semver at index-generation** (fixes CLI too); this client-side sort is defensive + correct regardless.

Filed from EcoDev workshop dogfooding (logos-co/ecosystem#170). Can't self-apply labels — please tag `from eco dev`.