### PR TITLE
fix(deps): restore aboutToUnload() on the generated UI plugin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -780,11 +780,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787270089,
-        "narHash": "sha256-GYaGET2WTGChyl3bJVXE4ioapC3aLILK4tQI/C29FSY=",
+        "lastModified": 1787433464,
+        "narHash": "sha256-ZSJp2KorECpaDI1k88r8NiQcZzSjF5GzSS2HU7B5nZM=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "667990f28c1736ac902ac1d2cb46a0aeaf42467a",
+        "rev": "acea0d24e2bcf9a11973aac15df4dc12913f9b02",
         "type": "github"
       },
       "original": {
@@ -806,7 +806,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_16",
+        "logos-protocol": "logos-protocol_17",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -878,7 +878,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_21",
+        "logos-protocol": "logos-protocol_22",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -937,7 +937,7 @@
       "inputs": {
         "logos-lidl": "logos-lidl_52",
         "logos-nix": "logos-nix_172",
-        "logos-protocol": "logos-protocol_24",
+        "logos-protocol": "logos-protocol_25",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -1013,7 +1013,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_27",
+        "logos-protocol": "logos-protocol_28",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -1085,7 +1085,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_32",
+        "logos-protocol": "logos-protocol_33",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -1113,7 +1113,7 @@
       "inputs": {
         "logos-lidl": "logos-lidl_6",
         "logos-nix": "logos-nix_12",
-        "logos-protocol": "logos-protocol_2",
+        "logos-protocol": "logos-protocol_3",
         "nixpkgs": [
           "logos-module-builder",
           "logos-standalone-app",
@@ -1185,7 +1185,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_5",
+        "logos-protocol": "logos-protocol_6",
         "nixpkgs": [
           "logos-module-builder",
           "logos-standalone-app",
@@ -1253,7 +1253,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_10",
+        "logos-protocol": "logos-protocol_11",
         "nixpkgs": [
           "logos-module-builder",
           "logos-view-module-runtime",
@@ -1311,7 +1311,7 @@
       "inputs": {
         "logos-lidl": "logos-lidl_29",
         "logos-nix": "logos-nix_90",
-        "logos-protocol": "logos-protocol_13",
+        "logos-protocol": "logos-protocol_14",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -1564,7 +1564,7 @@
         "logos-nix": "logos-nix_49",
         "logos-package-manager": "logos-package-manager_2",
         "logos-plugin-qt": "logos-plugin-qt_7",
-        "logos-protocol": "logos-protocol_7",
+        "logos-protocol": "logos-protocol_8",
         "logos-qt-sdk": "logos-qt-sdk_4",
         "nixpkgs": [
           "logos-module-builder",
@@ -1601,7 +1601,7 @@
         "logos-nix": "logos-nix_127",
         "logos-package-manager": "logos-package-manager_5",
         "logos-plugin-qt": "logos-plugin-qt_17",
-        "logos-protocol": "logos-protocol_18",
+        "logos-protocol": "logos-protocol_19",
         "logos-qt-sdk": "logos-qt-sdk_9",
         "nixpkgs": [
           "package_downloader",
@@ -1639,7 +1639,7 @@
         "logos-nix": "logos-nix_209",
         "logos-package-manager": "logos-package-manager_8",
         "logos-plugin-qt": "logos-plugin-qt_27",
-        "logos-protocol": "logos-protocol_29",
+        "logos-protocol": "logos-protocol_30",
         "logos-qt-sdk": "logos-qt-sdk_14",
         "nixpkgs": [
           "package_manager",
@@ -2070,11 +2070,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -2411,11 +2411,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -4119,11 +4119,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1787365695,
-        "narHash": "sha256-f20KxGSgoll2cvtgxnASooKuZx87Ly9K7p5XtkN0V1Y=",
+        "lastModified": 1787447341,
+        "narHash": "sha256-I3BQnjqFns7ffilm2Z/hzsPMwwLnqvcLaV0o6OkVenc=",
         "owner": "logos-co",
         "repo": "logos-module-builder",
-        "rev": "352df67cd6cfa441397495876e21b0d5df93d9f6",
+        "rev": "e45caf147bdb938a2e2025ef52f1a25070841711",
         "type": "github"
       },
       "original": {
@@ -4140,7 +4140,7 @@
         "logos-nix": "logos-nix_21",
         "logos-plugin-core": "logos-plugin-core_2",
         "logos-plugin-qt": "logos-plugin-qt_3",
-        "logos-protocol": "logos-protocol_3",
+        "logos-protocol": "logos-protocol_4",
         "logos-qt-sdk": "logos-qt-sdk_2",
         "logos-rust-sdk": "logos-rust-sdk_2",
         "logos-standalone-app": [
@@ -4187,7 +4187,7 @@
         "logos-nix": "logos-nix_82",
         "logos-plugin-core": "logos-plugin-core_3",
         "logos-plugin-qt": "logos-plugin-qt_11",
-        "logos-protocol": "logos-protocol_12",
+        "logos-protocol": "logos-protocol_13",
         "logos-qt-sdk": "logos-qt-sdk_6",
         "logos-rust-sdk": "logos-rust-sdk_3",
         "logos-standalone-app": "logos-standalone-app_2",
@@ -4226,7 +4226,7 @@
         "logos-nix": "logos-nix_99",
         "logos-plugin-core": "logos-plugin-core_4",
         "logos-plugin-qt": "logos-plugin-qt_13",
-        "logos-protocol": "logos-protocol_14",
+        "logos-protocol": "logos-protocol_15",
         "logos-qt-sdk": "logos-qt-sdk_7",
         "logos-rust-sdk": "logos-rust-sdk_4",
         "logos-standalone-app": [
@@ -4275,7 +4275,7 @@
         "logos-nix": "logos-nix_164",
         "logos-plugin-core": "logos-plugin-core_5",
         "logos-plugin-qt": "logos-plugin-qt_21",
-        "logos-protocol": "logos-protocol_23",
+        "logos-protocol": "logos-protocol_24",
         "logos-qt-sdk": "logos-qt-sdk_11",
         "logos-rust-sdk": "logos-rust-sdk_5",
         "logos-standalone-app": "logos-standalone-app_3",
@@ -4314,7 +4314,7 @@
         "logos-nix": "logos-nix_181",
         "logos-plugin-core": "logos-plugin-core_6",
         "logos-plugin-qt": "logos-plugin-qt_23",
-        "logos-protocol": "logos-protocol_25",
+        "logos-protocol": "logos-protocol_26",
         "logos-qt-sdk": "logos-qt-sdk_12",
         "logos-rust-sdk": "logos-rust-sdk_6",
         "logos-standalone-app": [
@@ -11417,11 +11417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787268499,
-        "narHash": "sha256-uYMUAOqwuJhA6KE7KddbaQAJZl55T/K4tZMoF02ShhQ=",
+        "lastModified": 1787435195,
+        "narHash": "sha256-/tkYJNXt9vZX2GFlZQmct/VeI3dvSP2V7Mwm6BhResQ=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "55713b9c799af3c73e176b2a22001a9aa7eb8a71",
+        "rev": "c459e477876175d9cba219d50f2efa241fef650c",
         "type": "github"
       },
       "original": {
@@ -11629,11 +11629,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787268499,
-        "narHash": "sha256-uYMUAOqwuJhA6KE7KddbaQAJZl55T/K4tZMoF02ShhQ=",
+        "lastModified": 1787435195,
+        "narHash": "sha256-/tkYJNXt9vZX2GFlZQmct/VeI3dvSP2V7Mwm6BhResQ=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "55713b9c799af3c73e176b2a22001a9aa7eb8a71",
+        "rev": "c459e477876175d9cba219d50f2efa241fef650c",
         "type": "github"
       },
       "original": {
@@ -12868,11 +12868,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787324808,
-        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
+        "lastModified": 1787430480,
+        "narHash": "sha256-TpbTH95fk8e1F5DGxTeX+5y1MilGoSfOp8/JIoU1PMI=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
+        "rev": "6c24fcb13229cda6ebe70205b4ecf00dacd0ed1e",
         "type": "github"
       },
       "original": {
@@ -12882,6 +12882,33 @@
       }
     },
     "logos-protocol_10": {
+      "inputs": {
+        "logos-nix": [
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_11": {
       "inputs": {
         "logos-nix": [
           "logos-module-builder",
@@ -12912,7 +12939,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_11": {
+    "logos-protocol_12": {
       "inputs": {
         "logos-nix": [
           "logos-module-builder",
@@ -12939,7 +12966,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_12": {
+    "logos-protocol_13": {
       "inputs": {
         "logos-nix": "logos-nix_87",
         "nixpkgs": [
@@ -12964,7 +12991,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_13": {
+    "logos-protocol_14": {
       "inputs": {
         "logos-nix": [
           "package_downloader",
@@ -12997,7 +13024,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_14": {
+    "logos-protocol_15": {
       "inputs": {
         "logos-nix": "logos-nix_104",
         "nixpkgs": [
@@ -13026,7 +13053,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_15": {
+    "logos-protocol_16": {
       "inputs": {
         "logos-nix": [
           "package_downloader",
@@ -13063,7 +13090,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_16": {
+    "logos-protocol_17": {
       "inputs": {
         "logos-nix": [
           "package_downloader",
@@ -13104,7 +13131,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_17": {
+    "logos-protocol_18": {
       "inputs": {
         "logos-nix": [
           "package_downloader",
@@ -13141,7 +13168,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_18": {
+    "logos-protocol_19": {
       "inputs": {
         "logos-nix": "logos-nix_134",
         "nixpkgs": [
@@ -13168,7 +13195,36 @@
         "type": "github"
       }
     },
-    "logos-protocol_19": {
+    "logos-protocol_2": {
+      "inputs": {
+        "logos-nix": [
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787324808,
+        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_20": {
       "inputs": {
         "logos-nix": [
           "package_downloader",
@@ -13197,67 +13253,36 @@
         "type": "github"
       }
     },
-    "logos-protocol_2": {
-      "inputs": {
-        "logos-nix": [
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_20": {
-      "inputs": {
-        "logos-nix": [
-          "package_downloader",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "package_downloader",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
     "logos-protocol_21": {
+      "inputs": {
+        "logos-nix": [
+          "package_downloader",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "package_downloader",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_22": {
       "inputs": {
         "logos-nix": [
           "package_downloader",
@@ -13290,7 +13315,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_22": {
+    "logos-protocol_23": {
       "inputs": {
         "logos-nix": [
           "package_downloader",
@@ -13319,7 +13344,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_23": {
+    "logos-protocol_24": {
       "inputs": {
         "logos-nix": "logos-nix_169",
         "nixpkgs": [
@@ -13344,7 +13369,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_24": {
+    "logos-protocol_25": {
       "inputs": {
         "logos-nix": [
           "package_manager",
@@ -13377,7 +13402,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_25": {
+    "logos-protocol_26": {
       "inputs": {
         "logos-nix": "logos-nix_186",
         "nixpkgs": [
@@ -13406,7 +13431,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_26": {
+    "logos-protocol_27": {
       "inputs": {
         "logos-nix": [
           "package_manager",
@@ -13443,7 +13468,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_27": {
+    "logos-protocol_28": {
       "inputs": {
         "logos-nix": [
           "package_manager",
@@ -13484,7 +13509,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_28": {
+    "logos-protocol_29": {
       "inputs": {
         "logos-nix": [
           "package_manager",
@@ -13521,7 +13546,38 @@
         "type": "github"
       }
     },
-    "logos-protocol_29": {
+    "logos-protocol_3": {
+      "inputs": {
+        "logos-nix": [
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_30": {
       "inputs": {
         "logos-nix": "logos-nix_216",
         "nixpkgs": [
@@ -13548,35 +13604,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_3": {
-      "inputs": {
-        "logos-nix": "logos-nix_26",
-        "nixpkgs": [
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_30": {
+    "logos-protocol_31": {
       "inputs": {
         "logos-nix": [
           "package_manager",
@@ -13605,7 +13633,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_31": {
+    "logos-protocol_32": {
       "inputs": {
         "logos-nix": [
           "package_manager",
@@ -13634,7 +13662,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_32": {
+    "logos-protocol_33": {
       "inputs": {
         "logos-nix": [
           "package_manager",
@@ -13667,7 +13695,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_33": {
+    "logos-protocol_34": {
       "inputs": {
         "logos-nix": [
           "package_manager",
@@ -13698,6 +13726,34 @@
     },
     "logos-protocol_4": {
       "inputs": {
+        "logos-nix": "logos-nix_26",
+        "nixpkgs": [
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_5": {
+      "inputs": {
         "logos-nix": [
           "logos-module-builder",
           "logos-standalone-app",
@@ -13731,7 +13787,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_5": {
+    "logos-protocol_6": {
       "inputs": {
         "logos-nix": [
           "logos-module-builder",
@@ -13770,7 +13826,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_6": {
+    "logos-protocol_7": {
       "inputs": {
         "logos-nix": [
           "logos-module-builder",
@@ -13805,7 +13861,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_7": {
+    "logos-protocol_8": {
       "inputs": {
         "logos-nix": "logos-nix_56",
         "nixpkgs": [
@@ -13831,7 +13887,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_8": {
+    "logos-protocol_9": {
       "inputs": {
         "logos-nix": [
           "logos-module-builder",
@@ -13850,33 +13906,6 @@
         "owner": "logos-co",
         "repo": "logos-protocol",
         "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_9": {
-      "inputs": {
-        "logos-nix": [
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
         "type": "github"
       },
       "original": {
@@ -13983,11 +14012,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787268585,
-        "narHash": "sha256-yDh1GpHNWAo7JlGvR83paJhFTCNLjDnLtxRxNl/1RzE=",
+        "lastModified": 1787442773,
+        "narHash": "sha256-XBztDKox0BmrTnIVVWji8Jhgh1dVKqAEqXj1dUlWIOE=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "4a1104cabb5647ef8524809c7021104e050cb529",
+        "rev": "4ab78a1a42f0db1ff97cc5d8a3fb9b41753e16c9",
         "type": "github"
       },
       "original": {
@@ -14690,6 +14719,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
+        "logos-protocol": "logos-protocol_2",
         "nixpkgs": [
           "logos-module-builder",
           "logos-rust-sdk",
@@ -14698,11 +14728,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787312984,
-        "narHash": "sha256-5tUekequUlrzhG7C005bm20zALXpLPw2K2SYl2eZL1I=",
+        "lastModified": 1787432825,
+        "narHash": "sha256-ewGa76Pym9ZQjtFP7Kwxfks9ys23AVd3Mx5GdzLQ2Dw=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "49dbb0768a9a18cfaf264cc3ecfa55cca2630157",
+        "rev": "2b88750085193aa4e2771e26e825a990a6caf91a",
         "type": "github"
       },
       "original": {
@@ -14965,7 +14995,7 @@
         "logos-liblogos": "logos-liblogos",
         "logos-nix": "logos-nix_59",
         "logos-plugin-qt": "logos-plugin-qt_8",
-        "logos-protocol": "logos-protocol_8",
+        "logos-protocol": "logos-protocol_9",
         "logos-qt-mcp": "logos-qt-mcp",
         "logos-view-module-runtime": [
           "logos-module-builder",
@@ -15003,7 +15033,7 @@
         "logos-liblogos": "logos-liblogos_2",
         "logos-nix": "logos-nix_137",
         "logos-plugin-qt": "logos-plugin-qt_18",
-        "logos-protocol": "logos-protocol_19",
+        "logos-protocol": "logos-protocol_20",
         "logos-qt-mcp": "logos-qt-mcp_2",
         "logos-view-module-runtime": [
           "package_downloader",
@@ -15043,7 +15073,7 @@
         "logos-liblogos": "logos-liblogos_3",
         "logos-nix": "logos-nix_219",
         "logos-plugin-qt": "logos-plugin-qt_28",
-        "logos-protocol": "logos-protocol_30",
+        "logos-protocol": "logos-protocol_31",
         "logos-qt-mcp": "logos-qt-mcp_3",
         "logos-view-module-runtime": [
           "package_manager",
@@ -15084,7 +15114,7 @@
         ],
         "logos-nix": "logos-nix_29",
         "logos-plugin-qt": "logos-plugin-qt_5",
-        "logos-protocol": "logos-protocol_4",
+        "logos-protocol": "logos-protocol_5",
         "logos-qt-sdk": "logos-qt-sdk_3",
         "nixpkgs": [
           "logos-module-builder",
@@ -15119,7 +15149,7 @@
         ],
         "logos-nix": "logos-nix_62",
         "logos-plugin-qt": "logos-plugin-qt_9",
-        "logos-protocol": "logos-protocol_9",
+        "logos-protocol": "logos-protocol_10",
         "logos-qt-sdk": "logos-qt-sdk_5",
         "nixpkgs": [
           "logos-module-builder",
@@ -15155,7 +15185,7 @@
         ],
         "logos-nix": "logos-nix_107",
         "logos-plugin-qt": "logos-plugin-qt_15",
-        "logos-protocol": "logos-protocol_15",
+        "logos-protocol": "logos-protocol_16",
         "logos-qt-sdk": "logos-qt-sdk_8",
         "nixpkgs": [
           "package_downloader",
@@ -15192,7 +15222,7 @@
         ],
         "logos-nix": "logos-nix_140",
         "logos-plugin-qt": "logos-plugin-qt_19",
-        "logos-protocol": "logos-protocol_20",
+        "logos-protocol": "logos-protocol_21",
         "logos-qt-sdk": "logos-qt-sdk_10",
         "nixpkgs": [
           "package_downloader",
@@ -15229,7 +15259,7 @@
         ],
         "logos-nix": "logos-nix_189",
         "logos-plugin-qt": "logos-plugin-qt_25",
-        "logos-protocol": "logos-protocol_26",
+        "logos-protocol": "logos-protocol_27",
         "logos-qt-sdk": "logos-qt-sdk_13",
         "nixpkgs": [
           "package_manager",
@@ -15266,7 +15296,7 @@
         ],
         "logos-nix": "logos-nix_222",
         "logos-plugin-qt": "logos-plugin-qt_29",
-        "logos-protocol": "logos-protocol_31",
+        "logos-protocol": "logos-protocol_32",
         "logos-qt-sdk": "logos-qt-sdk_15",
         "nixpkgs": [
           "package_manager",
@@ -15330,7 +15360,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_4",
         "logos-nix": "logos-nix_31",
         "logos-plugin-qt": "logos-plugin-qt_6",
-        "logos-protocol": "logos-protocol_6",
+        "logos-protocol": "logos-protocol_7",
         "nixpkgs": [
           "logos-module-builder",
           "logos-standalone-app",
@@ -15361,7 +15391,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_6",
         "logos-nix": "logos-nix_64",
         "logos-plugin-qt": "logos-plugin-qt_10",
-        "logos-protocol": "logos-protocol_11",
+        "logos-protocol": "logos-protocol_12",
         "nixpkgs": [
           "logos-module-builder",
           "logos-view-module-runtime",
@@ -15388,7 +15418,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_10",
         "logos-nix": "logos-nix_109",
         "logos-plugin-qt": "logos-plugin-qt_16",
-        "logos-protocol": "logos-protocol_17",
+        "logos-protocol": "logos-protocol_18",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -15420,7 +15450,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_12",
         "logos-nix": "logos-nix_142",
         "logos-plugin-qt": "logos-plugin-qt_20",
-        "logos-protocol": "logos-protocol_22",
+        "logos-protocol": "logos-protocol_23",
         "nixpkgs": [
           "package_downloader",
           "logos-module-builder",
@@ -15448,7 +15478,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_16",
         "logos-nix": "logos-nix_191",
         "logos-plugin-qt": "logos-plugin-qt_26",
-        "logos-protocol": "logos-protocol_28",
+        "logos-protocol": "logos-protocol_29",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -15480,7 +15510,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_18",
         "logos-nix": "logos-nix_224",
         "logos-plugin-qt": "logos-plugin-qt_30",
-        "logos-protocol": "logos-protocol_33",
+        "logos-protocol": "logos-protocol_34",
         "nixpkgs": [
           "package_manager",
           "logos-module-builder",
@@ -15517,11 +15547,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787164758,
-        "narHash": "sha256-RFu9RTD4RVbwoKJN01qmt00eqF8ZwKHm3gcbYc95HyE=",
+        "lastModified": 1787441236,
+        "narHash": "sha256-dDbws6OlaOw5YTCHQfVLXqF+ssD6Fs3vCrLqOthEYOI=",
         "owner": "logos-co",
         "repo": "logos-view-module",
-        "rev": "1f95a75f836a7601bde3b488dc2e773c4ebb9068",
+        "rev": "d6c8885494524504cc5ea9dcfdad54a98ed26ea4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
`logos-module-builder` `352df67` → `e45caf1`, which carries `logos-view-module` `1f95a75` → `d6c8885` and with it the module teardown hook that generated view plugins had been missing (module-builder#214).

See the [logos-test-modules PR](https://github.com/logos-co/logos-test-modules/pulls) for the full story — the same bump there is what unblocks [logos-basecamp#358](https://github.com/logos-co/logos-basecamp/pull/358).

Only `logos-module-builder` moves at root. Verified on **aarch64-darwin and x86_64-linux**: every check plus every module output.

## A correction worth recording

`352df67` is module-builder **#210**, which *predates* the #211 migration — so this repo was never inside the "#211 → #214 broken window" I first assumed. It was on the older `logos-qt-generator` path, whose ui emitter also had no hook. Same outcome, different cause; the bump crosses into the fixed state either way.

## Instrument caveat

`lm methods` is **not** a raw meta-object dump for provider plugins — `logos-module/src/logos_module.cpp:283` takes a `LogosProviderPlugin` early-return that never reaches the walk at `:315`, so lifecycle methods are omitted and it reports *absent* for a plugin that `nm -gU | c++filt` shows carrying them. Verifying a hook this way needs `QPluginLoader` + `QMetaObject`, or `nm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)